### PR TITLE
UUID was missing from LineItem

### DIFF
--- a/invoices.go
+++ b/invoices.go
@@ -27,6 +27,7 @@ type Invoice struct {
 
 // LineItem represents a singular items of the invoices
 type LineItem struct {
+	UUID                   string `json:"uuid,omitempty"`
 	AmountInCents          int    `json:"amount_in_cents,omitempty"`
 	CancelledAt            string `json:"cancelled_at,omitempty"`
 	Description            string `json:"description,omitempty"`


### PR DESCRIPTION
The UUID should be included in the struct so consumers of the API can save LineItem mappings on their end.