### PR TITLE
Wrapping all requests with Exponential Back-off

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ export GODEBUG=http2client=0
 
 ## Usage
 
+### Rate Limits
+The library limits itself on HTTP 429, so that you don't have to manually handle rate limiting. See:
+[ChartMogul: Rate Limits](https://dev.chartmogul.com/docs/rate-limits) &amp;
+[BackOff constants](https://godoc.org/github.com/cenkalti/backoff#pkg-constants).
+Exponential back-off algorithm is used.
+
+The API calls will retry automatically and block (several minutes), therefore it's still advisable
+to only use reasonable parallelism. In case it keeps failing after maximum retry period, it will
+return the HTTP 429 error.
+
+Note: the `Ping` doesn't retry.
+
 ### Import API
 
 Available methods in Import API:

--- a/generic.go
+++ b/generic.go
@@ -1,8 +1,11 @@
 package chartmogul
 
 import (
+	"errors"
+	"net/http"
 	"strings"
 
+	"github.com/cenkalti/backoff"
 	"github.com/parnurzeal/gorequest"
 )
 
@@ -11,44 +14,100 @@ import (
 // so these methods do *not* properly check types.
 // Eg. nils cannot be easily checked (without reflection).
 
+// static internal error helper
+var errRateLimit = errors.New("Rate limit reached")
+
 // CREATE
 func (api API) create(path string, input interface{}, output interface{}) error {
-	res, body, errs := api.req(gorequest.New().Post(prepareURL(path))).
-		SendStruct(input).
-		EndStruct(output)
+	var res gorequest.Response
+	var body []byte
+	var errs []error
+	// This request object will be reused for consequent retries
+	req := api.req(gorequest.New().
+		Post(prepareURL(path))).
+		SendStruct(input)
 
+	// Retry on HTTP 429 rate limit, see:
+	// https://dev.chartmogul.com/docs/rate-limits
+	// https://godoc.org/github.com/cenkalti/backoff#pkg-constants
+	backoff.Retry(func() error {
+		res, body, errs = req.EndStruct(output)
+		if res.StatusCode == http.StatusTooManyRequests {
+			return errRateLimit
+		}
+		return nil
+	}, backoff.NewExponentialBackOff())
+
+	// wrapping []errors into compatible error & making HTTPError
 	return wrapErrors(res, body, errs)
 }
 
 // READ
 func (api API) list(path string, output interface{}, query ...interface{}) error {
+	var res gorequest.Response
+	var body []byte
+	var errs []error
 	req := api.req(gorequest.New().Get(prepareURL(path)))
 	for _, q := range query {
 		req.Query(q)
 	}
-	res, body, errs := req.EndStruct(output)
+
+	backoff.Retry(func() error {
+		res, body, errs = req.EndStruct(output)
+		if res.StatusCode == http.StatusTooManyRequests {
+			return errRateLimit
+		}
+		return nil
+	}, backoff.NewExponentialBackOff())
 
 	return wrapErrors(res, body, errs)
 }
 
 func (api API) retrieve(path string, uuid string, output interface{}) error {
+	var res gorequest.Response
+	var body []byte
+	var errs []error
 	path = strings.Replace(path, ":uuid", uuid, 1)
-	res, body, errs := api.req(gorequest.New().Get(prepareURL(path))).
-		EndStruct(output)
+	req := api.req(gorequest.New().Get(prepareURL(path)))
+
+	backoff.Retry(func() error {
+		res, body, errs = req.EndStruct(output)
+		if res.StatusCode == http.StatusTooManyRequests {
+			return errRateLimit
+		}
+		return nil
+	}, backoff.NewExponentialBackOff())
+
 	return wrapErrors(res, body, errs)
 }
 
 // UPDATE
 func (api API) merge(path string, input interface{}) error {
-	res, body, errs := api.req(gorequest.New().Post(prepareURL(path))).
-		SendStruct(input).
-		End()
+	var res gorequest.Response
+	var body string
+	var errs []error
+	req := api.req(gorequest.New().
+		Post(prepareURL(path))).
+		SendStruct(input)
+
+	backoff.Retry(func() error {
+		res, body, errs = req.End()
+		if res.StatusCode == http.StatusTooManyRequests {
+			return errRateLimit
+		}
+		return nil
+	}, backoff.NewExponentialBackOff())
+
 	return wrapErrors(res, []byte(body), errs)
 }
 
 // updateImpl adds another meta level, because this same pattern
 // uses multiple HTTP methods in  API.
 func (api API) updateImpl(path string, uuid string, input interface{}, output interface{}, method string) error {
+	var res gorequest.Response
+	var body []byte
+	var errs []error
+
 	path = strings.Replace(path, ":uuid", uuid, 1)
 	path = prepareURL(path)
 	req := gorequest.New()
@@ -60,10 +119,15 @@ func (api API) updateImpl(path string, uuid string, input interface{}, output in
 	case "putTo":
 		req = req.Put(path)
 	}
+	req = api.req(req).SendStruct(input)
 
-	res, body, errs := api.req(req).
-		SendStruct(input).
-		EndStruct(output)
+	backoff.Retry(func() error {
+		res, body, errs = req.EndStruct(output)
+		if res.StatusCode == http.StatusTooManyRequests {
+			return errRateLimit
+		}
+		return nil
+	}, backoff.NewExponentialBackOff())
 
 	return wrapErrors(res, body, errs)
 }
@@ -84,16 +148,38 @@ func (api API) putTo(path string, uuid string, input interface{}, output interfa
 
 // DELETE
 func (api API) delete(path string, uuid string) error {
+	var res gorequest.Response
+	var body string
+	var errs []error
 	path = strings.Replace(path, ":uuid", uuid, 1)
-	res, body, errs := api.req(gorequest.New().Delete(prepareURL(path))).
-		End()
+	req := api.req(gorequest.New().Delete(prepareURL(path)))
+
+	backoff.Retry(func() error {
+		res, body, errs = req.End()
+		if res.StatusCode == http.StatusTooManyRequests {
+			return errRateLimit
+		}
+		return nil
+	}, backoff.NewExponentialBackOff())
+
 	return wrapErrors(res, []byte(body), errs)
 }
 
 func (api API) deleteWhat(path string, uuid string, input interface{}, output interface{}) error {
+	var res gorequest.Response
+	var body []byte
+	var errs []error
 	path = strings.Replace(path, ":uuid", uuid, 1)
-	res, body, errs := api.req(gorequest.New().Delete(prepareURL(path))).
-		SendStruct(input).
-		EndStruct(output)
+	req := api.req(gorequest.New().Delete(prepareURL(path))).
+		SendStruct(input)
+
+	backoff.Retry(func() error {
+		res, body, errs = req.EndStruct(output)
+		if res.StatusCode == http.StatusTooManyRequests {
+			return errRateLimit
+		}
+		return nil
+	}, backoff.NewExponentialBackOff())
+
 	return wrapErrors(res, body, errs)
 }

--- a/generic_test.go
+++ b/generic_test.go
@@ -1,0 +1,25 @@
+package chartmogul
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequest(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				// do nothing
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		AccountToken: "token",
+		AccessKey:    "key",
+	}
+	tested.delete("path1/:uuid", "uuid1")
+}
+
+//TODO: write unit tests for multiple parallel backed off requests

--- a/ping.go
+++ b/ping.go
@@ -11,7 +11,7 @@ type Ping struct {
 
 const pingEndpoint = "ping"
 
-// Ping is the authentication test endpoint.
+// Ping is the authentication test endpoint. Doesn't retry on 429.
 //
 // See https://dev.chartmogul.com/v1.0/docs/authentication
 func (api API) Ping() (bool, error) {


### PR DESCRIPTION
* all but ping wrapped in exp. back off to avoid 429
* will add similar to other libraries, so that customers don't have to handle manually
* I've tested manually, but would like to write unit tests later this week, unfortunately no time now