### PR TITLE
Retry on network errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,12 @@ export GODEBUG=http2client=0
 ## Usage
 
 ### Rate Limits
-The library limits itself on HTTP 429, so that you don't have to manually handle rate limiting. See:
+The library retries on HTTP 429 (rate limit reached), so that you don't have to manually handle rate limiting.
+See:
 [ChartMogul: Rate Limits](https://dev.chartmogul.com/docs/rate-limits) &amp;
 [BackOff constants](https://godoc.org/github.com/cenkalti/backoff#pkg-constants).
 Exponential back-off algorithm is used.
+It also automatically retries on network errors, eg. when the server can't be reached.
 
 The API calls will retry automatically and block (several minutes), therefore it's still advisable
 to only use reasonable parallelism. In case it keeps failing after maximum retry period, it will

--- a/generic.go
+++ b/generic.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cenkalti/backoff"
 	"github.com/parnurzeal/gorequest"
 )
@@ -33,10 +32,6 @@ func (api API) create(path string, input interface{}, output interface{}) error 
 			SendStruct(input).
 			EndStruct(output)
 		if res == nil || res.StatusCode == http.StatusTooManyRequests {
-			logrus.Info(errs)
-			if res != nil {
-				logrus.Info(res.StatusCode)
-			}
 			return errRetry
 		}
 		return nil

--- a/generic.go
+++ b/generic.go
@@ -15,7 +15,7 @@ import (
 // Eg. nils cannot be easily checked (without reflection).
 
 // static internal error helper
-var errRateLimit = errors.New("Rate limit reached")
+var errRetry = errors.New("Retrying")
 
 // CREATE
 func (api API) create(path string, input interface{}, output interface{}) error {
@@ -27,13 +27,13 @@ func (api API) create(path string, input interface{}, output interface{}) error 
 		Post(prepareURL(path))).
 		SendStruct(input)
 
-	// Retry on HTTP 429 rate limit, see:
+	// Retry on HTTP 429 rate limit, or network error, see:
 	// https://dev.chartmogul.com/docs/rate-limits
 	// https://godoc.org/github.com/cenkalti/backoff#pkg-constants
 	backoff.Retry(func() error {
 		res, body, errs = req.EndStruct(output)
-		if res.StatusCode == http.StatusTooManyRequests {
-			return errRateLimit
+		if res == nil || res.StatusCode == http.StatusTooManyRequests {
+			return errRetry
 		}
 		return nil
 	}, backoff.NewExponentialBackOff())
@@ -54,8 +54,8 @@ func (api API) list(path string, output interface{}, query ...interface{}) error
 
 	backoff.Retry(func() error {
 		res, body, errs = req.EndStruct(output)
-		if res.StatusCode == http.StatusTooManyRequests {
-			return errRateLimit
+		if res == nil || res.StatusCode == http.StatusTooManyRequests {
+			return errRetry
 		}
 		return nil
 	}, backoff.NewExponentialBackOff())
@@ -72,8 +72,8 @@ func (api API) retrieve(path string, uuid string, output interface{}) error {
 
 	backoff.Retry(func() error {
 		res, body, errs = req.EndStruct(output)
-		if res.StatusCode == http.StatusTooManyRequests {
-			return errRateLimit
+		if res == nil || res.StatusCode == http.StatusTooManyRequests {
+			return errRetry
 		}
 		return nil
 	}, backoff.NewExponentialBackOff())
@@ -92,8 +92,8 @@ func (api API) merge(path string, input interface{}) error {
 
 	backoff.Retry(func() error {
 		res, body, errs = req.End()
-		if res.StatusCode == http.StatusTooManyRequests {
-			return errRateLimit
+		if res == nil || res.StatusCode == http.StatusTooManyRequests {
+			return errRetry
 		}
 		return nil
 	}, backoff.NewExponentialBackOff())
@@ -123,8 +123,8 @@ func (api API) updateImpl(path string, uuid string, input interface{}, output in
 
 	backoff.Retry(func() error {
 		res, body, errs = req.EndStruct(output)
-		if res.StatusCode == http.StatusTooManyRequests {
-			return errRateLimit
+		if res == nil || res.StatusCode == http.StatusTooManyRequests {
+			return errRetry
 		}
 		return nil
 	}, backoff.NewExponentialBackOff())
@@ -156,8 +156,8 @@ func (api API) delete(path string, uuid string) error {
 
 	backoff.Retry(func() error {
 		res, body, errs = req.End()
-		if res.StatusCode == http.StatusTooManyRequests {
-			return errRateLimit
+		if res == nil || res.StatusCode == http.StatusTooManyRequests {
+			return errRetry
 		}
 		return nil
 	}, backoff.NewExponentialBackOff())
@@ -175,8 +175,8 @@ func (api API) deleteWhat(path string, uuid string, input interface{}, output in
 
 	backoff.Retry(func() error {
 		res, body, errs = req.EndStruct(output)
-		if res.StatusCode == http.StatusTooManyRequests {
-			return errRateLimit
+		if res == nil || res.StatusCode == http.StatusTooManyRequests {
+			return errRetry
 		}
 		return nil
 	}, backoff.NewExponentialBackOff())


### PR DESCRIPTION
* found out today while trying integration from localhost that lost connections cause `nil pointer panic`
* broadened the retry from just rate limit to also network errors
* this may cause stuff to be sent twice, if the original request actually went through.