### PR TITLE
[DP-516] System field support

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,10 @@ To work on the library:
 * Push to the branch (`git push origin my-new-feature`)
 * Create a new Pull Request
 
-* We recommend [`github.com/davecgh/go-spew/spew`](https://github.com/davecgh/go-spew/spew) for debugging data (reference documentation output done using this library).
+### Recommended
+
+* [`github.com/davecgh/go-spew/spew`](https://github.com/davecgh/go-spew/spew) for debugging data (reference documentation output done using this library).
+* add pre-commit hook `go test ./...` (in `.git/hooks/pre-commit`) to have a working state always.
 
 ### Testing
 * Use `net/http/httptest` for mocking HTTP server directly, see file `generic_test.go` for examples.

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -51,9 +51,10 @@ type IApi interface {
 	Ping() (res bool, err error)
 	// Data sources
 	CreateDataSource(name string) (*DataSource, error)
-	CreateDataSource2(dataSource *DataSource) (*DataSource, error)
+	CreateDataSourceWithSystem(dataSource *DataSource) (*DataSource, error)
 	RetrieveDataSource(dataSourceUUID string) (*DataSource, error)
 	ListDataSources() (*DataSources, error)
+	ListDataSourcesWithFilters(listDataSourcesParams *ListDataSourcesParams) (*DataSources, error)
 	PurgeDataSource(dataSourceUUID string) error
 	DeleteDataSource(dataSourceUUID string) error
 	// Invoices

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -51,9 +51,10 @@ type IApi interface {
 	Ping() (res bool, err error)
 	// Data sources
 	CreateDataSource(name string) (*DataSource, error)
+	CreateDataSource2(dataSource *DataSource) (*DataSource, error)
 	RetrieveDataSource(dataSourceUUID string) (*DataSource, error)
 	ListDataSources() (*DataSources, error)
-	PurgeDataSource(uuid string) error
+	PurgeDataSource(dataSourceUUID string) error
 	DeleteDataSource(dataSourceUUID string) error
 	// Invoices
 	CreateInvoices(invoices []*Invoice, customerUUID string) (*Invoices, error)

--- a/customers_test.go
+++ b/customers_test.go
@@ -132,7 +132,6 @@ func TestFormattingOfSourceInCustomAttributeUpdate(t *testing.T) {
 		spew.Dump(err)
 		t.Fatal("Not expected to fail")
 	}
-
 }
 
 func TestPurgeCustomer(t *testing.T) {
@@ -160,5 +159,78 @@ func TestPurgeCustomer(t *testing.T) {
 		spew.Dump(err)
 		t.Fatal("Not expected to fail")
 	}
+}
 
+func TestNilListCustomers(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/customers" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"entries": [],
+												 "current_page": 1,
+												 "total_pages": 1,
+												 "has_more": false,
+												 "per_page": 200,
+												 "page": 1}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		AccountToken: "token",
+		AccessKey:    "key",
+	}
+	customers, err := tested.ListCustomers(nil)
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if len(customers.Entries) != 0 || customers.PerPage != 200 {
+		spew.Dump(customers)
+		t.Fatal("Unexpected result")
+	}
+}
+
+func TestSystemListCustomers(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/customers?system=whatnot" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"entries": [],
+												 "current_page": 1,
+												 "total_pages": 1,
+												 "has_more": false,
+												 "per_page": 200,
+												 "page": 1}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		AccountToken: "token",
+		AccessKey:    "key",
+	}
+	customers, err := tested.ListCustomers(&ListCustomersParams{System: "whatnot"})
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if len(customers.Entries) != 0 || customers.PerPage != 200 {
+		spew.Dump(customers)
+		t.Fatal("Unexpected result")
+	}
 }

--- a/customers_test.go
+++ b/customers_test.go
@@ -172,12 +172,8 @@ func TestNilListCustomers(t *testing.T) {
 					t.Errorf("Unexpected URI %v", r.RequestURI)
 				}
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"entries": [],
-												 "current_page": 1,
-												 "total_pages": 1,
-												 "has_more": false,
-												 "per_page": 200,
-												 "page": 1}`))
+				w.Write([]byte(`{"entries": [],"current_page": 1,"total_pages": 1,
+					"has_more": false,"per_page": 200,"page": 1}`))
 			}))
 	defer server.Close()
 	SetURL(server.URL + "/v/%v")

--- a/datasources.go
+++ b/datasources.go
@@ -16,6 +16,12 @@ type DataSources struct {
 	DataSources []*DataSource `json:"data_sources"`
 }
 
+// ListDataSourcesParams are optional parameters for listing data sources.
+type ListDataSourcesParams struct {
+	Name   string `json:"name,omitempty"`
+	System string `json:"system,omitempty"`
+}
+
 // createDataSourceCall represents arguments to be marshalled into JSON.
 type createDataSourceCall struct {
 	Name string `json:"name"`
@@ -60,6 +66,20 @@ func (api API) RetrieveDataSource(dataSourceUUID string) (*DataSource, error) {
 func (api API) ListDataSources() (*DataSources, error) {
 	ds := &DataSources{}
 	err := api.list(dataSourcesEndpoint, ds)
+	return ds, err
+}
+
+// ListDataSources2 lists all available Data Sources (no paging).
+// * Allows filtering.
+//
+// See https://dev.chartmogul.com/v1.0/reference#data-sources
+func (api API) ListDataSources2(listDataSourcesParams *ListDataSourcesParams) (*DataSources, error) {
+	ds := &DataSources{}
+	query := make([]interface{}, 0, 1)
+	if listDataSourcesParams != nil {
+		query = append(query, *listDataSourcesParams)
+	}
+	err := api.list(dataSourcesEndpoint, ds, query...)
 	return ds, err
 }
 

--- a/datasources.go
+++ b/datasources.go
@@ -36,6 +36,16 @@ func (api API) CreateDataSource(name string) (*DataSource, error) {
 	return ds, err
 }
 
+// CreateDataSource2 creates an API Data Source in ChartMogul.
+// * Allows other parameters than just the name.
+//
+// See https://dev.chartmogul.com/v1.0/reference#data-sources
+func (api API) CreateDataSource2(dataSource *DataSource) (*DataSource, error) {
+	ds := &DataSource{}
+	err := api.create(dataSourcesEndpoint, dataSource, ds)
+	return ds, err
+}
+
 // RetrieveDataSource returns one Data Source by UUID.
 //
 // See https://dev.chartmogul.com/v1.0/reference#data-sources
@@ -63,6 +73,6 @@ func (api API) DeleteDataSource(uuid string) error {
 // PurgeDataSource deletes all the data in the data source, but keeps the UUID.
 //
 // See https://dev.chartmogul.com/v1.0/reference#data-sources
-func (api API) PurgeDataSource(uuid string) error {
-	return api.delete(purgeDataSourceEndpoint, uuid)
+func (api API) PurgeDataSource(dataSourceUUID string) error {
+	return api.delete(purgeDataSourceEndpoint, dataSourceUUID)
 }

--- a/datasources.go
+++ b/datasources.go
@@ -42,11 +42,11 @@ func (api API) CreateDataSource(name string) (*DataSource, error) {
 	return ds, err
 }
 
-// CreateDataSource2 creates an API Data Source in ChartMogul.
+// CreateDataSourceWithSystem creates an API Data Source in ChartMogul.
 // * Allows other parameters than just the name.
 //
 // See https://dev.chartmogul.com/v1.0/reference#data-sources
-func (api API) CreateDataSource2(dataSource *DataSource) (*DataSource, error) {
+func (api API) CreateDataSourceWithSystem(dataSource *DataSource) (*DataSource, error) {
 	ds := &DataSource{}
 	err := api.create(dataSourcesEndpoint, dataSource, ds)
 	return ds, err
@@ -69,11 +69,11 @@ func (api API) ListDataSources() (*DataSources, error) {
 	return ds, err
 }
 
-// ListDataSources2 lists all available Data Sources (no paging).
+// ListDataSourcesWithFilters lists all available Data Sources (no paging).
 // * Allows filtering.
 //
 // See https://dev.chartmogul.com/v1.0/reference#data-sources
-func (api API) ListDataSources2(listDataSourcesParams *ListDataSourcesParams) (*DataSources, error) {
+func (api API) ListDataSourcesWithFilters(listDataSourcesParams *ListDataSourcesParams) (*DataSources, error) {
 	ds := &DataSources{}
 	query := make([]interface{}, 0, 1)
 	if listDataSourcesParams != nil {

--- a/mock_chartmogul/chartmogul.go
+++ b/mock_chartmogul/chartmogul.go
@@ -106,6 +106,17 @@ func (_mr *_MockIApiRecorder) CreateDataSource(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDataSource", arg0)
 }
 
+func (_m *MockIApi) CreateDataSource2(_param0 *chartmogul_go.DataSource) (*chartmogul_go.DataSource, error) {
+	ret := _m.ctrl.Call(_m, "CreateDataSource2", _param0)
+	ret0, _ := ret[0].(*chartmogul_go.DataSource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIApiRecorder) CreateDataSource2(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDataSource2", arg0)
+}
+
 func (_m *MockIApi) CreateInvoices(_param0 []*chartmogul_go.Invoice, _param1 string) (*chartmogul_go.Invoices, error) {
 	ret := _m.ctrl.Call(_m, "CreateInvoices", _param0, _param1)
 	ret0, _ := ret[0].(*chartmogul_go.Invoices)

--- a/mock_chartmogul/chartmogul.go
+++ b/mock_chartmogul/chartmogul.go
@@ -106,15 +106,15 @@ func (_mr *_MockIApiRecorder) CreateDataSource(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDataSource", arg0)
 }
 
-func (_m *MockIApi) CreateDataSource2(_param0 *chartmogul_go.DataSource) (*chartmogul_go.DataSource, error) {
-	ret := _m.ctrl.Call(_m, "CreateDataSource2", _param0)
+func (_m *MockIApi) CreateDataSourceWithSystem(_param0 *chartmogul_go.DataSource) (*chartmogul_go.DataSource, error) {
+	ret := _m.ctrl.Call(_m, "CreateDataSourceWithSystem", _param0)
 	ret0, _ := ret[0].(*chartmogul_go.DataSource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIApiRecorder) CreateDataSource2(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDataSource2", arg0)
+func (_mr *_MockIApiRecorder) CreateDataSourceWithSystem(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDataSourceWithSystem", arg0)
 }
 
 func (_m *MockIApi) CreateInvoices(_param0 []*chartmogul_go.Invoice, _param1 string) (*chartmogul_go.Invoices, error) {
@@ -231,6 +231,17 @@ func (_m *MockIApi) ListDataSources() (*chartmogul_go.DataSources, error) {
 
 func (_mr *_MockIApiRecorder) ListDataSources() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListDataSources")
+}
+
+func (_m *MockIApi) ListDataSourcesWithFilters(_param0 *chartmogul_go.ListDataSourcesParams) (*chartmogul_go.DataSources, error) {
+	ret := _m.ctrl.Call(_m, "ListDataSourcesWithFilters", _param0)
+	ret0, _ := ret[0].(*chartmogul_go.DataSources)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIApiRecorder) ListDataSourcesWithFilters(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListDataSourcesWithFilters", arg0)
 }
 
 func (_m *MockIApi) ListInvoices(_param0 *chartmogul_go.Cursor, _param1 string) (*chartmogul_go.Invoices, error) {

--- a/plans.go
+++ b/plans.go
@@ -27,6 +27,7 @@ type Plans struct {
 type ListPlansParams struct {
 	DataSourceUUID string `json:"data_source_uuid"`
 	ExternalID     string `json:"external_id,omitempty"`
+	System         string `json:"system,omitempty"`
 	Cursor
 }
 
@@ -51,7 +52,11 @@ func (api API) RetrievePlan(planUUID string) (*Plan, error) {
 // See https://dev.chartmogul.com/v1.0/reference#plans
 func (api API) ListPlans(listPlansParams *ListPlansParams) (*Plans, error) {
 	result := &Plans{}
-	return result, api.list(plansEndpoint, result, *listPlansParams)
+	query := make([]interface{}, 0, 1)
+	if listPlansParams != nil {
+		query = append(query, *listPlansParams)
+	}
+	return result, api.list(plansEndpoint, result, query...)
 }
 
 // UpdatePlan returns list of plans.


### PR DESCRIPTION
### Support system param on Data Source creation
* Introducing alternative method, because changing the frequently-used original would break everyone's code, which is not nice.
* Anyway, this is a feature for advanced integrations only.

### Other fixes
* OK, I've just piggybacked here a few more fixes:
1. previously passing `nil` as optional filtering params on list would cause an error
2. added filtering to list data sources
3. added system filter param to `plans`.

### Fun
ad 1. no, you can't check pointer on struct for nil, if you don't know its type. So, it's obviously great copying code around.
ad 2. chose to make new method, not to break API. I could use variadric argument, but that could be confusing. Go doesn't have overloading or optional params. Obviously, who needs that.