### PR TITLE
Fix for IsInvoiceAndTransactionAlreadyExist [ch1722]

### DIFF
--- a/chartmogul.go
+++ b/chartmogul.go
@@ -164,7 +164,7 @@ func (e Errors) IsInvoiceAndTransactionAlreadyExist() (is bool) {
 	if e == nil {
 		return
 	}
-	if len(e) == 2 {
+	if len(e) != 2 {
 		return
 	}
 	msg1, ok1 := e[ErrKeyExternalID]

--- a/chartmogul_test.go
+++ b/chartmogul_test.go
@@ -43,4 +43,14 @@ func TestPing(t *testing.T) {
 	}
 }
 
+func TestIsInvoiceAndTransactionAlreadyExist(t *testing.T) {
+	err := Errors(map[string]string{
+		"transactions.external_id": "has already been taken",
+		"external_id":              "The external ID for this invoice already exists in our system.",
+	})
+	if !err.IsInvoiceAndTransactionAlreadyExist() {
+		t.Error("expected IsInvoiceAndTransactionAlreadyExist to be true")
+	}
+}
+
 //TODO: unit tests against mocked HTTP server.


### PR DESCRIPTION
Return false if error length does not equal to 2