### PR TITLE
Fixed subscription cancel params to allow empty slice [ch10713]

### DIFF
--- a/subscriptions.go
+++ b/subscriptions.go
@@ -28,8 +28,8 @@ type Subscriptions struct {
 
 // CancelSubscriptionParams represents arguments to be marshalled into JSON.
 type CancelSubscriptionParams struct {
-	CancelledAt       string   `json:"cancelled_at,omitempty"`
-	CancellationDates []string `json:"cancellation_dates,omitempty"`
+	CancelledAt       string    `json:"cancelled_at,omitempty"`
+	CancellationDates *[]string `json:"cancellation_dates,omitempty"`
 }
 
 // CancelSubscription creates an Import API Data Source in ChartMogul.

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -70,3 +70,45 @@ func TestConnectSubscriptions(t *testing.T) {
 		t.Fatal("Expected to retry")
 	}
 }
+
+func TestCancelSubscriptionParams(t *testing.T) {
+	emptySlice := []string{}
+	notEmptySlice := []string{"some-date"}
+	testCases := map[string]struct {
+		param *CancelSubscriptionParams
+		exp   string
+	}{
+		"clearing cancellation history": {
+			param: &CancelSubscriptionParams{
+				CancellationDates: &emptySlice,
+			},
+			exp: `{"cancellation_dates":[]}`,
+		},
+		"setting cancellation history": {
+			param: &CancelSubscriptionParams{
+				CancellationDates: &notEmptySlice,
+			},
+			exp: `{"cancellation_dates":["some-date"]}`,
+		},
+		"not using cancellation history": {
+			param: &CancelSubscriptionParams{
+				CancelledAt: "some-date",
+			},
+			exp: `{"cancelled_at":"some-date"}`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := json.Marshal(tc.param)
+			if err != nil {
+				spew.Dump(err)
+				t.Error("Expected not error")
+			}
+			if string(got) != tc.exp {
+				spew.Dump(tc.exp, string(got))
+				t.Error("Doesn't equal expected value")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Empty slice for `CancellationDates` is valid value. It means clear any cancellation history of the subscription. But since we are using `omitempty` tag, we could never send empty slice.

Removing `omitempty` tag doesn't solve the problem either. If `CancellationDates` is left out and only `CancelledAt` field is set, we get `{"cancelled_at":"some-date", "cancellation_dates": null}` as encoded value. Sending `null` in `cancellation_dates` would also mean clearing cancellation history.