### PR TITLE
Retry request on network and retryable server errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
   - go: 1.10.x
   - go: 1.11.x
     env: GO111MODULE=on
-  - go: master
+  - go: 1.12.x
     env: GO111MODULE=on
     script: make lint test
 


### PR DESCRIPTION
Currently, the library only retries on `429` error, this PR will add support to retry on network error and server errors like: `500`, `502` and `503`

Story details: https://app.clubhouse.io/chartmogul/story/12501