### PR TITLE
Ubuntu to 18.04, add newer Go versions (Travis) [ch21988]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os: linux
+dist: bionic
+
 language: go
 
 matrix:
@@ -11,6 +14,8 @@ matrix:
   - go: 1.12.x
     env: GO111MODULE=on
     script: make lint test
+  - go: 1.13.x
+  - go: 1.14.x
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
Update build, try building under newer versions of Go.
Note: newer Go versions default to GO111MODULE=auto, so it's not necessary to set :+1: 