### PR TITLE
Add Account API endpoint[ch28502]

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,15 @@ api.MetricsListActivities(&Cursor{}, "customerUUID")
 ```
 
 
+### Account
+
+Availiable methods:
+
+```go
+api.RetrieveAccount()
+```
+
+
 ### Errors
 
 The library returns parsed errors inside the structs as from the REST API,

--- a/account.go
+++ b/account.go
@@ -6,12 +6,10 @@ const (
 
 // Account details in ChartMogul
 type Account struct {
-	Name        string `json:"name,omitempty"`
-	Currency    string `json:"currency,omitempty"`
-	TimeZone    string `json:"time_zone,omitempty"`
-	WeekStartOn string `json:"week_start_on,omitempty"`
-
-	Errors Errors `json:"errors,omitempty"`
+	Name        string `json:"name"`
+	Currency    string `json:"currency"`
+	TimeZone    string `json:"time_zone"`
+	WeekStartOn string `json:"week_start_on"`
 }
 
 // RetrieveAccount returns details of current account.

--- a/account.go
+++ b/account.go
@@ -1,0 +1,22 @@
+package chartmogul
+
+const (
+	accountEndpoint = "account"
+)
+
+// Account details in ChartMogul
+type Account struct {
+	Name        string `json:"name,omitempty"`
+	Currency    string `json:"currency,omitempty"`
+	TimeZone    string `json:"time_zone,omitempty"`
+	WeekStartOn string `json:"week_start_on,omitempty"`
+
+	Errors Errors `json:"errors,omitempty"`
+}
+
+// RetrieveAccount returns details of current account.
+func (api API) RetrieveAccount() (*Account, error) {
+	result := &Account{}
+	accountUUID := ""
+	return result, api.retrieve(accountEndpoint, accountUUID, result)
+}

--- a/account_test.go
+++ b/account_test.go
@@ -1,0 +1,51 @@
+package chartmogul
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+const accountExample = `{
+	"name": "Example Test Company",
+	"currency": "EUR",
+	"time_zone": "Europe/Berlin",
+	"week_start_on": "sunday"
+}`
+
+func TestRetrieveAccount(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "GET"
+				if r.Method != expectedMethod {
+					t.Errorf("Requested method expected: %v, actual: %v", expectedMethod, r.Method)
+				}
+				expected := "/v/account"
+				path := r.URL.Path
+				if path != expected {
+					t.Errorf("Requested path expected: %v, actual: %v", expected, path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+				w.Write([]byte(accountExample)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		AccountToken: "token",
+		AccessKey:    "key",
+	}
+	account, err := tested.RetrieveAccount()
+
+	if account.Name != "Example Test Company" || account.Currency != "EUR" || account.TimeZone != "Europe/Berlin" || account.WeekStartOn != "sunday" {
+		spew.Dump(account)
+		t.Error("Unexpected account details")
+	}
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+}

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -124,6 +124,9 @@ type IApi interface {
 	// Metrics - Subscriptions & Activities
 	MetricsListSubscriptions(cursor *Cursor, customerUUID string) (*MetricsSubscriptions, error)
 	MetricsListActivities(cursor *Cursor, customerUUID string) (*MetricsActivities, error)
+
+	// Account
+	RetrieveAccount() (*Account, error)
 }
 
 // API is the handle for communicating with Chartmogul.

--- a/generic.go
+++ b/generic.go
@@ -65,11 +65,14 @@ func (api API) list(path string, output interface{}, query ...interface{}) error
 	return wrapErrors(res, body, errs)
 }
 
+// RETRIEVE
 func (api API) retrieve(path string, uuid string, output interface{}) error {
 	var res gorequest.Response
 	var body []byte
 	var errs []error
-	path = strings.Replace(path, ":uuid", uuid, 1)
+	if uuid != "" {
+		path = strings.Replace(path, ":uuid", uuid, 1)
+	}
 
 	// nolint:errcheck
 	backoff.Retry(func() error {


### PR DESCRIPTION
Account details such as name, currency, time zone and week start on are now available via API.
The go library was updated to include this new endpoint.

```Go
api.RetrieveAccount()
```

Find more information [here](https://www.notion.so/chartmogul/WIP-App-Make-account-details-available-via-API-calls-379e0e91d8d94a37ae04ffdfcf57c8c7) on notion.

Link to [Clubhouse Story](https://app.clubhouse.io/chartmogul/story/28502/update-libraries-for-account-api-endpoints).

