### PR TITLE
Support customer scoped Activities and unscoped Activities [ch30595]

### DIFF
--- a/2.0-Upgrade.md
+++ b/2.0-Upgrade.md
@@ -1,0 +1,10 @@
+# Upgrading to chartmogul-go 2.0.0
+
+The package upgrade brings breaking changes to the Metrics API. All other APIs remain unaffected. Please note the following changes:
+
+* If you used the Metrics API to get a customer's activities or subscriptions, make the following changes in the namespace
+  - `api.MetricsListSubscriptions(&cm.Cursor{PerPage: 1},"cus_922c2672-ee04-11e6-bea8-7fac984477db")` should be replaced by `api.MetricsListCustomerSubscriptions(&cm.Cursor{PerPage: 1},"cus_922c2672-ee04-11e6-bea8-7fac984477db")`
+  - `api.MetricsListActivities(&cm.Cursor{PerPage: 1},"cus_922c2672-ee04-11e6-bea8-7fac984477db")
+` should be replace by `api.MetricsListCustomerActivities(&cm.Cursor{PerPage: 1},"cus_922c2672-ee04-11e6-bea8-7fac984477db")`
+
+

--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ api.MetricsRetrieveCustomerChurnRate(&MetricsFilter{})
 api.MetricsRetrieveMRRChurnRate(&MetricsFilter{})
 api.MetricsRetrieveLTV(&MetricsFilter{})
 
-api.MetricsListCustomerSubscriptions(&Cursor{}, "customerUUID") // >= v2.0.0
-api.MetricsListCustomerActivities(&Cursor{}, "customerUUID") // >= v2.0.0
+api.MetricsListCustomerSubscriptions(&Cursor{}, "customerUUID")
+api.MetricsListCustomerActivities(&Cursor{}, "customerUUID")
 
 api.MetricsListActivities(&Cursor{PerPage: 100})
 ```

--- a/README.md
+++ b/README.md
@@ -190,8 +190,10 @@ api.MetricsRetrieveCustomerChurnRate(&MetricsFilter{})
 api.MetricsRetrieveMRRChurnRate(&MetricsFilter{})
 api.MetricsRetrieveLTV(&MetricsFilter{})
 
-api.MetricsListSubscriptions(&Cursor{}, "customerUUID")
-api.MetricsListActivities(&Cursor{}, "customerUUID")
+api.MetricsListCustomerSubscriptions(&Cursor{}, "customerUUID") // >= v2.0.0
+api.MetricsListCustomerActivities(&Cursor{}, "customerUUID") // >= v2.0.0
+
+api.MetricsListActivities(&Cursor{PerPage: 100})
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ api.MetricsRetrieveLTV(&MetricsFilter{})
 api.MetricsListCustomerSubscriptions(&Cursor{}, "customerUUID")
 api.MetricsListCustomerActivities(&Cursor{}, "customerUUID")
 
-api.MetricsListActivities(&Cursor{PerPage: 100})
+api.MetricsListActivities(&cm.MetricsListActivitiesParams{StartDate: "2016-09-16T09:28:10Z", AnchorCursor: cm.AnchorCursor{PerPage: 5, StartAfter: "b45b1d3f-3823-424f-ab47-5a1d0c00a7f6"}})
 ```
 
 

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -124,7 +124,7 @@ type IApi interface {
 	// Metrics - Subscriptions & Activities
 	MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID string) (*MetricsCustomerSubscriptions, error)
 	MetricsListCustomerActivities(cursor *Cursor, customerUUID string) (*MetricsCustomerActivities, error)
-	MetricsListActivities(cursor *Cursor) (*MetricsActivities, error)
+    MetricsListActivities(MetricsListActivitiesParams *MetricsListActivitiesParams) (*MetricsActivities, error)
 
 	// Account
 	RetrieveAccount() (*Account, error)
@@ -142,6 +142,11 @@ type API struct {
 type Cursor struct {
 	Page    uint32 `json:"page,omitempty"`
 	PerPage uint32 `json:"per_page,omitempty"`
+}
+
+type AnchorCursor struct {
+    PerPage uint32 `json:"per-page,omitempty"`
+    StartAfter string `json:"start-after,omitempty"`
 }
 
 // Errors contains error feedback from ChartMogul

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -124,7 +124,7 @@ type IApi interface {
 	// Metrics - Subscriptions & Activities
 	MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID string) (*MetricsCustomerSubscriptions, error)
 	MetricsListCustomerActivities(cursor *Cursor, customerUUID string) (*MetricsCustomerActivities, error)
-    MetricsListActivities(MetricsListActivitiesParams *MetricsListActivitiesParams) (*MetricsActivities, error)
+	MetricsListActivities(MetricsListActivitiesParams *MetricsListActivitiesParams) (*MetricsActivities, error)
 
 	// Account
 	RetrieveAccount() (*Account, error)
@@ -145,8 +145,8 @@ type Cursor struct {
 }
 
 type AnchorCursor struct {
-    PerPage uint32 `json:"per-page,omitempty"`
-    StartAfter string `json:"start-after,omitempty"`
+	PerPage    uint32 `json:"per-page,omitempty"`
+	StartAfter string `json:"start-after,omitempty"`
 }
 
 // Errors contains error feedback from ChartMogul

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -122,8 +122,9 @@ type IApi interface {
 	MetricsRetrieveLTV(metricsFilter *MetricsFilter) (*LTVResult, error)
 
 	// Metrics - Subscriptions & Activities
-	MetricsListSubscriptions(cursor *Cursor, customerUUID string) (*MetricsSubscriptions, error)
-	MetricsListActivities(cursor *Cursor, customerUUID string) (*MetricsActivities, error)
+	MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID string) (*MetricsCustomerSubscriptions, error)
+	MetricsListCustomerActivities(cursor *Cursor, customerUUID string) (*MetricsCustomerActivities, error)
+	MetricsListActivities(cursor *Cursor) (*MetricsActivities, error)
 
 	// Account
 	RetrieveAccount() (*Account, error)

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -144,8 +144,10 @@ type Cursor struct {
 	PerPage uint32 `json:"per_page,omitempty"`
 }
 
+// AnchorCursor contains query parameters for anchor based pagination used for some APIs in ChartMogul.
 type AnchorCursor struct {
 	PerPage    uint32 `json:"per-page,omitempty"`
+    //StartAfter is used to get the next set of Entries and its value should be the UUID of last Entry from previous response.
 	StartAfter string `json:"start-after,omitempty"`
 }
 

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -146,8 +146,8 @@ type Cursor struct {
 
 // AnchorCursor contains query parameters for anchor based pagination used for some APIs in ChartMogul.
 type AnchorCursor struct {
-	PerPage    uint32 `json:"per-page,omitempty"`
-    //StartAfter is used to get the next set of Entries and its value should be the UUID of last Entry from previous response.
+	PerPage uint32 `json:"per-page,omitempty"`
+	//StartAfter is used to get the next set of Entries and its value should be the UUID of last Entry from previous response.
 	StartAfter string `json:"start-after,omitempty"`
 }
 

--- a/metrics_activities.go
+++ b/metrics_activities.go
@@ -2,20 +2,20 @@ package chartmogul
 
 // MetricsActivity represents Metrics API activity in ChartMogul.
 type MetricsActivity struct {
-	Date                    string  `json:"date"`
-	ActivityArr             float64 `json:"activity-arr"`
-	ActivityMrr             float64 `json:"activity-mrr"`
-	ActivityMrrMovement     float64 `json:"activity-mrr-movement"`
-	Currency                string  `json:"currency"`
-	Description             string  `json:"description"`
-	Type                    string  `json:"type"`
-	SubscriptionExternalID  string  `json:"subscription-external-id"`
-	PlanExternalID          string  `json:"plan-external-id"`
-	CustomerName            string  `json:"customer-name"`
-	CustomerUUID            string  `json:"customer-uuid"`
-	CustomerExternalID      string  `json:"customer-external-id"`
-	BillingConnectorUUID    string  `json:"billing-connector-uuid"`
-	UUID                    string  `json:"uuid"`
+	Date                   string  `json:"date"`
+	ActivityArr            float64 `json:"activity-arr"`
+	ActivityMrr            float64 `json:"activity-mrr"`
+	ActivityMrrMovement    float64 `json:"activity-mrr-movement"`
+	Currency               string  `json:"currency"`
+	Description            string  `json:"description"`
+	Type                   string  `json:"type"`
+	SubscriptionExternalID string  `json:"subscription-external-id"`
+	PlanExternalID         string  `json:"plan-external-id"`
+	CustomerName           string  `json:"customer-name"`
+	CustomerUUID           string  `json:"customer-uuid"`
+	CustomerExternalID     string  `json:"customer-external-id"`
+	BillingConnectorUUID   string  `json:"billing-connector-uuid"`
+	UUID                   string  `json:"uuid"`
 }
 
 // MetricsActivities is the result of listing activities in Metrics API.

--- a/metrics_activities.go
+++ b/metrics_activities.go
@@ -26,21 +26,21 @@ type MetricsActivities struct {
 }
 
 type MetricsListActivitiesParams struct {
-	Type       string `json:"type,omitempty"`
-	StartDate  string `json:"start-date,omitempty"`
-	EndDate    string `json:"end-date,omitempty"`
-	Order      string `json:"order,omitempty"`
-    AnchorCursor
+	Type      string `json:"type,omitempty"`
+	StartDate string `json:"start-date,omitempty"`
+	EndDate   string `json:"end-date,omitempty"`
+	Order     string `json:"order,omitempty"`
+	AnchorCursor
 }
 
 const metricsActivitiesEndpoint = "activities"
 
 // MetricsListActivities lists all activities for an account
 func (api API) MetricsListActivities(listActivitiesParams *MetricsListActivitiesParams) (*MetricsActivities, error) {
-    result := &MetricsActivities{}
-    query := make([]interface{}, 0, 1)
-    if listActivitiesParams != nil {
-        query = append(query, *listActivitiesParams)
-    }
-    return result, api.list(metricsActivitiesEndpoint, result, query...)
+	result := &MetricsActivities{}
+	query := make([]interface{}, 0, 1)
+	if listActivitiesParams != nil {
+		query = append(query, *listActivitiesParams)
+	}
+	return result, api.list(metricsActivitiesEndpoint, result, query...)
 }

--- a/metrics_activities.go
+++ b/metrics_activities.go
@@ -1,18 +1,21 @@
 package chartmogul
 
-import "strings"
-
 // MetricsActivity represents Metrics API activity in ChartMogul.
 type MetricsActivity struct {
-	ID                  uint64  `json:"id"`
-	Date                string  `json:"date"`
-	ActivityArr         float64 `json:"activity-arr"`
-	ActivityMrr         float64 `json:"activity-mrr"`
-	ActivityMrrMovement float64 `json:"activity-mrr-movement"`
-	Currency            string  `json:"currency"`
-	CurrencySign        string  `json:"currency-sign"`
-	Description         string  `json:"description"`
-	Type                string  `json:"type"`
+	Date                    string  `json:"date"`
+	ActivityArr             float64 `json:"activity-arr"`
+	ActivityMrr             float64 `json:"activity-mrr"`
+	ActivityMrrMovement     float64 `json:"activity-mrr-movement"`
+	Currency                string  `json:"currency"`
+	Description             string  `json:"description"`
+	Type                    string  `json:"type"`
+	SubscriptionExternalID  string  `json:"subscription-external-id"`
+	PlanExternalID          string  `json:"plan-external-id"`
+	CustomerName            string  `json:"customer-name"`
+	CustomerUUID            string  `json:"customer-uuid"`
+	CustomerExternalID      string  `json:"customer-external-id"`
+	BillingConnectorUUID    string  `json:"billing-connector-uuid"`
+	UUID                    string  `json:"uuid"`
 }
 
 // MetricsActivities is the result of listing activities in Metrics API.
@@ -20,20 +23,18 @@ type MetricsActivities struct {
 	Entries []*MetricsActivity `json:"entries"`
 	HasMore bool               `json:"has_more"`
 	PerPage uint32             `json:"per_page"`
-	Page    uint32             `json:"page"`
 }
 
-const metricsActivitiesEndpoint = "customers/:uuid/activities"
+const metricsActivitiesEndpoint = "activities"
 
 // MetricsListActivities lists all activities for cutomer of a given UUID.
 //
 // See https://dev.chartmogul.com/v1.0/reference#list-customer-activities
-func (api API) MetricsListActivities(cursor *Cursor, customerUUID string) (*MetricsActivities, error) {
+func (api API) MetricsListActivities(cursor *Cursor) (*MetricsActivities, error) {
 	result := &MetricsActivities{}
-	path := strings.Replace(metricsActivitiesEndpoint, ":uuid", customerUUID, 1)
 	query := make([]interface{}, 0, 1)
 	if cursor != nil {
 		query = append(query, *cursor)
 	}
-	return result, api.list(path, result, query...)
+	return result, api.list(metricsActivitiesEndpoint, result, query...)
 }

--- a/metrics_activities.go
+++ b/metrics_activities.go
@@ -25,16 +25,22 @@ type MetricsActivities struct {
 	PerPage uint32             `json:"per_page"`
 }
 
+type MetricsListActivitiesParams struct {
+	Type       string `json:"type,omitempty"`
+	StartDate  string `json:"start-date,omitempty"`
+	EndDate    string `json:"end-date,omitempty"`
+	Order      string `json:"order,omitempty"`
+    AnchorCursor
+}
+
 const metricsActivitiesEndpoint = "activities"
 
-// MetricsListActivities lists all activities for cutomer of a given UUID.
-//
-// See https://dev.chartmogul.com/v1.0/reference#list-customer-activities
-func (api API) MetricsListActivities(cursor *Cursor) (*MetricsActivities, error) {
-	result := &MetricsActivities{}
-	query := make([]interface{}, 0, 1)
-	if cursor != nil {
-		query = append(query, *cursor)
-	}
-	return result, api.list(metricsActivitiesEndpoint, result, query...)
+// MetricsListActivities lists all activities for an account
+func (api API) MetricsListActivities(listActivitiesParams *MetricsListActivitiesParams) (*MetricsActivities, error) {
+    result := &MetricsActivities{}
+    query := make([]interface{}, 0, 1)
+    if listActivitiesParams != nil {
+        query = append(query, *listActivitiesParams)
+    }
+    return result, api.list(metricsActivitiesEndpoint, result, query...)
 }

--- a/metrics_activities_test.go
+++ b/metrics_activities_test.go
@@ -16,7 +16,7 @@ func TestListActivities(t *testing.T) {
 				if r.Method != "GET" {
 					t.Errorf("Unexpected method %v", r.Method)
 				}
-				if r.RequestURI != "/v/activities?type=new_biz" {
+				if r.RequestURI != "/v/activities?per-page=5&start-after=b45b1d3f-3823-424f-ab47-5a1d0c00a7f6&type=new_biz" {
 					t.Errorf("Unexpected URI %v", r.RequestURI)
 				}
 				w.WriteHeader(http.StatusOK)
@@ -47,7 +47,7 @@ func TestListActivities(t *testing.T) {
 		AccountToken: "token",
 		AccessKey:    "key",
 	}
-	activities, err := tested.MetricsListActivities(&MetricsListActivitiesParams{Type: "new_biz"})
+	activities, err := tested.MetricsListActivities(&MetricsListActivitiesParams{Type: "new_biz", AnchorCursor: AnchorCursor{PerPage: 5, StartAfter: "b45b1d3f-3823-424f-ab47-5a1d0c00a7f6"}})
 
 	if err != nil {
 		spew.Dump(err)

--- a/metrics_activities_test.go
+++ b/metrics_activities_test.go
@@ -53,7 +53,8 @@ func TestListActivities(t *testing.T) {
 		spew.Dump(err)
 		t.Fatal("Not expected to fail")
 	}
-	if len(activities.Entries) == 0 {
+	if len(activities.Entries) == 0||
+        activities.Entries[0].UUID != "f1a49735-21c7-4e3f-9ddc-67927aaadcf4" {
 		spew.Dump(activities)
 		t.Fatal("Unexpected result")
 	}

--- a/metrics_activities_test.go
+++ b/metrics_activities_test.go
@@ -53,8 +53,8 @@ func TestListActivities(t *testing.T) {
 		spew.Dump(err)
 		t.Fatal("Not expected to fail")
 	}
-	if len(activities.Entries) == 0||
-        activities.Entries[0].UUID != "f1a49735-21c7-4e3f-9ddc-67927aaadcf4" {
+	if len(activities.Entries) == 0 ||
+		activities.Entries[0].UUID != "f1a49735-21c7-4e3f-9ddc-67927aaadcf4" {
 		spew.Dump(activities)
 		t.Fatal("Unexpected result")
 	}

--- a/metrics_activities_test.go
+++ b/metrics_activities_test.go
@@ -22,23 +22,23 @@ func TestListActivities(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				//nolint
 				w.Write([]byte(`{"entries": [{
-                                              "description": "purchased the plan_11 plan",
-                                              "activity-mrr-movement": 6000,
-                                              "activity-mrr": 6000,
-                                              "activity-arr": 72000,
-                                              "date": "2020-05-06T01:00:00",
-                                              "type": "new_biz",
-                                              "currency": "USD",
-                                              "subscription-external-id": "sub_2",
-                                              "plan-external-id": "11",
-                                              "customer-name": "customer_2",
-                                              "customer-uuid": "8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7",
-                                              "customer-external-id": "customer_2",
-                                              "billing-connector-uuid": "99076cb8-97a1-11eb-8798-a73b507e7929",
-                                              "uuid": "f1a49735-21c7-4e3f-9ddc-67927aaadcf4"
-                                            }],
-											"has_more": false,
-										    "per_page": 200}`))
+												"description": "purchased the plan_11 plan",
+												"activity-mrr-movement": 6000,
+												"activity-mrr": 6000,
+												"activity-arr": 72000,
+												"date": "2020-05-06T01:00:00",
+												"type": "new_biz",
+												"currency": "USD",
+												"subscription-external-id": "sub_2",
+												"plan-external-id": "11",
+												"customer-name": "customer_2",
+												"customer-uuid": "8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7",
+												"customer-external-id": "customer_2",
+												"billing-connector-uuid": "99076cb8-97a1-11eb-8798-a73b507e7929",
+												"uuid": "f1a49735-21c7-4e3f-9ddc-67927aaadcf4"
+												}],
+								"has_more": false,
+								"per_page": 200}`))
 			}))
 	defer server.Close()
 	SetURL(server.URL + "/v/%v")

--- a/metrics_activities_test.go
+++ b/metrics_activities_test.go
@@ -22,23 +22,23 @@ func TestListActivities(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				//nolint
 				w.Write([]byte(`{"entries": [{
-"description": "purchased the plan_11 plan",
-"activity-mrr-movement": 6000,
-"activity-mrr": 6000,
-"activity-arr": 72000,
-"date": "2020-05-06T01:00:00",
-"type": "new_biz",
-"currency": "USD",
-"subscription-external-id": "sub_2",
-"plan-external-id": "11",
-"customer-name": "customer_2",
-"customer-uuid": "8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7",
-"customer-external-id": "customer_2",
-"billing-connector-uuid": "99076cb8-97a1-11eb-8798-a73b507e7929",
-"uuid": "f1a49735-21c7-4e3f-9ddc-67927aaadcf4"
-}],
-"has_more": false,
-"per_page": 200}`))
+									"description": "purchased the plan_11 plan",
+									"activity-mrr-movement": 6000,
+									"activity-mrr": 6000,
+									"activity-arr": 72000,
+									"date": "2020-05-06T01:00:00",
+									"type": "new_biz",
+									"currency": "USD",
+									"subscription-external-id": "sub_2",
+									"plan-external-id": "11",
+									"customer-name": "customer_2",
+									"customer-uuid": "8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7",
+									"customer-external-id": "customer_2",
+									"billing-connector-uuid": "99076cb8-97a1-11eb-8798-a73b507e7929",
+									"uuid": "f1a49735-21c7-4e3f-9ddc-67927aaadcf4"
+								}],
+								"has_more": false,
+								"per_page": 200}`))
 			}))
 	defer server.Close()
 	SetURL(server.URL + "/v/%v")

--- a/metrics_activities_test.go
+++ b/metrics_activities_test.go
@@ -22,23 +22,23 @@ func TestListActivities(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				//nolint
 				w.Write([]byte(`{"entries": [{
-												"description": "purchased the plan_11 plan",
-												"activity-mrr-movement": 6000,
-												"activity-mrr": 6000,
-												"activity-arr": 72000,
-												"date": "2020-05-06T01:00:00",
-												"type": "new_biz",
-												"currency": "USD",
-												"subscription-external-id": "sub_2",
-												"plan-external-id": "11",
-												"customer-name": "customer_2",
-												"customer-uuid": "8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7",
-												"customer-external-id": "customer_2",
-												"billing-connector-uuid": "99076cb8-97a1-11eb-8798-a73b507e7929",
-												"uuid": "f1a49735-21c7-4e3f-9ddc-67927aaadcf4"
-												}],
-								"has_more": false,
-								"per_page": 200}`))
+"description": "purchased the plan_11 plan",
+"activity-mrr-movement": 6000,
+"activity-mrr": 6000,
+"activity-arr": 72000,
+"date": "2020-05-06T01:00:00",
+"type": "new_biz",
+"currency": "USD",
+"subscription-external-id": "sub_2",
+"plan-external-id": "11",
+"customer-name": "customer_2",
+"customer-uuid": "8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7",
+"customer-external-id": "customer_2",
+"billing-connector-uuid": "99076cb8-97a1-11eb-8798-a73b507e7929",
+"uuid": "f1a49735-21c7-4e3f-9ddc-67927aaadcf4"
+}],
+"has_more": false,
+"per_page": 200}`))
 			}))
 	defer server.Close()
 	SetURL(server.URL + "/v/%v")

--- a/metrics_activities_test.go
+++ b/metrics_activities_test.go
@@ -1,0 +1,60 @@
+package chartmogul
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// Test list activities tests.
+func TestListActivities(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/activities?type=new_biz" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				//nolint
+				w.Write([]byte(`{"entries": [{
+                                              "description": "purchased the plan_11 plan",
+                                              "activity-mrr-movement": 6000,
+                                              "activity-mrr": 6000,
+                                              "activity-arr": 72000,
+                                              "date": "2020-05-06T01:00:00",
+                                              "type": "new_biz",
+                                              "currency": "USD",
+                                              "subscription-external-id": "sub_2",
+                                              "plan-external-id": "11",
+                                              "customer-name": "customer_2",
+                                              "customer-uuid": "8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7",
+                                              "customer-external-id": "customer_2",
+                                              "billing-connector-uuid": "99076cb8-97a1-11eb-8798-a73b507e7929",
+                                              "uuid": "f1a49735-21c7-4e3f-9ddc-67927aaadcf4"
+                                            }],
+											"has_more": false,
+										    "per_page": 200}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		AccountToken: "token",
+		AccessKey:    "key",
+	}
+	activities, err := tested.MetricsListActivities(&MetricsListActivitiesParams{Type: "new_biz"})
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if len(activities.Entries) == 0 {
+		spew.Dump(activities)
+		t.Fatal("Unexpected result")
+	}
+}

--- a/metrics_customer_activities.go
+++ b/metrics_customer_activities.go
@@ -18,9 +18,9 @@ type MetricsCustomerActivity struct {
 // MetricsCustomerActivities is the result of listing activities in Metrics API.
 type MetricsCustomerActivities struct {
 	Entries []*MetricsCustomerActivity `json:"entries"`
-	HasMore bool               `json:"has_more"`
-	PerPage uint32             `json:"per_page"`
-	Page    uint32             `json:"page"`
+	HasMore bool                       `json:"has_more"`
+	PerPage uint32                     `json:"per_page"`
+	Page    uint32                     `json:"page"`
 }
 
 const metricsCustomerActivitiesEndpoint = "customers/:uuid/activities"

--- a/metrics_customer_activities.go
+++ b/metrics_customer_activities.go
@@ -1,0 +1,39 @@
+package chartmogul
+
+import "strings"
+
+// MetricsCustomerActivity represents Metrics API activity in ChartMogul.
+type MetricsCustomerActivity struct {
+	ID                  uint64  `json:"id"`
+	Date                string  `json:"date"`
+	ActivityArr         float64 `json:"activity-arr"`
+	ActivityMrr         float64 `json:"activity-mrr"`
+	ActivityMrrMovement float64 `json:"activity-mrr-movement"`
+	Currency            string  `json:"currency"`
+	CurrencySign        string  `json:"currency-sign"`
+	Description         string  `json:"description"`
+	Type                string  `json:"type"`
+}
+
+// MetricsCustomerActivities is the result of listing activities in Metrics API.
+type MetricsCustomerActivities struct {
+	Entries []*MetricsCustomerActivity `json:"entries"`
+	HasMore bool               `json:"has_more"`
+	PerPage uint32             `json:"per_page"`
+	Page    uint32             `json:"page"`
+}
+
+const metricsCustomerActivitiesEndpoint = "customers/:uuid/activities"
+
+// MetricsListCustomerActivities lists all activities for cutomer of a given UUID.
+//
+// See https://dev.chartmogul.com/v1.0/reference#list-customer-activities
+func (api API) MetricsListCustomerActivities(cursor *Cursor, customerUUID string) (*MetricsCustomerActivities, error) {
+	result := &MetricsCustomerActivities{}
+	path := strings.Replace(metricsCustomerActivitiesEndpoint, ":uuid", customerUUID, 1)
+	query := make([]interface{}, 0, 1)
+	if cursor != nil {
+		query = append(query, *cursor)
+	}
+	return result, api.list(path, result, query...)
+}

--- a/metrics_customer_activities_test.go
+++ b/metrics_customer_activities_test.go
@@ -33,9 +33,9 @@ func TestListCustomerActivities(t *testing.T) {
                                                 "type": "new_biz",
                                                 "subscription-external-id": "1"
                                             }],
-											"has_more": false,
-										    "per_page": 200,
-                                            "page": 1}`))
+                                "has_more": false,
+                                "per_page": 200,
+                                "page": 1}`))
 			}))
 	defer server.Close()
 	SetURL(server.URL + "/v/%v")
@@ -50,8 +50,8 @@ func TestListCustomerActivities(t *testing.T) {
 		spew.Dump(err)
 		t.Fatal("Not expected to fail")
 	}
-	if len(activities.Entries) == 0||
-        activities.Entries[0].Date != "2015-06-09T13:16:00+00:00" {
+	if len(activities.Entries) == 0 ||
+		activities.Entries[0].Date != "2015-06-09T13:16:00+00:00" {
 		spew.Dump(activities)
 		t.Fatal("Unexpected result")
 	}

--- a/metrics_customer_activities_test.go
+++ b/metrics_customer_activities_test.go
@@ -1,0 +1,58 @@
+package chartmogul
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// Test list activities tests.
+func TestListCustomerActivities(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/customers/cus_8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7/activities" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				//nolint
+				w.Write([]byte(`{"entries": [{
+                                                "activity-arr": 24000,
+                                                "activity-mrr": 2000,
+                                                "activity-mrr-movement": 2000,
+                                                "currency": "USD",
+                                                "currency-sign": "$",
+                                                "date": "2015-06-09T13:16:00+00:00",
+                                                "description": "purchased the Silver Monthly plan (1)",
+                                                "id": 48730,
+                                                "type": "new_biz",
+                                                "subscription-external-id": "1"
+                                            }],
+											"has_more": false,
+										    "per_page": 200,
+                                            "page": 1}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		AccountToken: "token",
+		AccessKey:    "key",
+	}
+	activities, err := tested.MetricsListCustomerActivities(&Cursor{}, "cus_8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7")
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if len(activities.Entries) == 0||
+        activities.Entries[0].Date != "2015-06-09T13:16:00+00:00" {
+		spew.Dump(activities)
+		t.Fatal("Unexpected result")
+	}
+}

--- a/metrics_customer_activities_test.go
+++ b/metrics_customer_activities_test.go
@@ -22,20 +22,20 @@ func TestListCustomerActivities(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				//nolint
 				w.Write([]byte(`{"entries": [{
-                                                "activity-arr": 24000,
-                                                "activity-mrr": 2000,
-                                                "activity-mrr-movement": 2000,
-                                                "currency": "USD",
-                                                "currency-sign": "$",
-                                                "date": "2015-06-09T13:16:00+00:00",
-                                                "description": "purchased the Silver Monthly plan (1)",
-                                                "id": 48730,
-                                                "type": "new_biz",
-                                                "subscription-external-id": "1"
-                                            }],
-                                "has_more": false,
-                                "per_page": 200,
-                                "page": 1}`))
+									"activity-arr": 24000,
+									"activity-mrr": 2000,
+									"activity-mrr-movement": 2000,
+									"currency": "USD",
+									"currency-sign": "$",
+									"date": "2015-06-09T13:16:00+00:00",
+									"description": "purchased the Silver Monthly plan (1)",
+									"id": 48730,
+									"type": "new_biz",
+									"subscription-external-id": "1"
+								}],
+								"has_more": false,
+								"per_page": 200,
+								"page": 1}`))
 			}))
 	defer server.Close()
 	SetURL(server.URL + "/v/%v")

--- a/metrics_customer_subscriptions.go
+++ b/metrics_customer_subscriptions.go
@@ -22,9 +22,9 @@ type MetricsCustomerSubscription struct {
 // MetricsCustomerSubscriptions is the result of listing subscriptions in Metrics API.
 type MetricsCustomerSubscriptions struct {
 	Entries []*MetricsCustomerSubscription `json:"entries"`
-	HasMore bool                   `json:"has_more"`
-	PerPage uint32                 `json:"per_page"`
-	Page    uint32                 `json:"page"`
+	HasMore bool                           `json:"has_more"`
+	PerPage uint32                         `json:"per_page"`
+	Page    uint32                         `json:"page"`
 }
 
 const metricsCustomerSubscriptionsEndpoint = "customers/:uuid/subscriptions"

--- a/metrics_customer_subscriptions.go
+++ b/metrics_customer_subscriptions.go
@@ -2,8 +2,8 @@ package chartmogul
 
 import "strings"
 
-// MetricsSubscription represents Metrics API subscription in ChartMogul.
-type MetricsSubscription struct {
+// MetricsCustomerSubscription represents Metrics API subscription in ChartMogul.
+type MetricsCustomerSubscription struct {
 	ID                uint64  `json:"id"`
 	ExternalID        string  `json:"external_id"`
 	Plan              string  `json:"plan"`
@@ -19,22 +19,22 @@ type MetricsSubscription struct {
 	CurrencySign      string  `json:"currency-sign"`
 }
 
-// MetricsSubscriptions is the result of listing subscriptions in Metrics API.
-type MetricsSubscriptions struct {
-	Entries []*MetricsSubscription `json:"entries"`
+// MetricsCustomerSubscriptions is the result of listing subscriptions in Metrics API.
+type MetricsCustomerSubscriptions struct {
+	Entries []*MetricsCustomerSubscription `json:"entries"`
 	HasMore bool                   `json:"has_more"`
 	PerPage uint32                 `json:"per_page"`
 	Page    uint32                 `json:"page"`
 }
 
-const metricsSubscriptionsEndpoint = "customers/:uuid/subscriptions"
+const metricsCustomerSubscriptionsEndpoint = "customers/:uuid/subscriptions"
 
 // MetricsListSubscriptions lists all subscriptions for cutomer of a given UUID.
 //
 // See https://dev.chartmogul.com/v1.0/reference#list-customer-subscriptions
-func (api API) MetricsListSubscriptions(cursor *Cursor, customerUUID string) (*MetricsSubscriptions, error) {
-	result := &MetricsSubscriptions{}
-	path := strings.Replace(metricsSubscriptionsEndpoint, ":uuid", customerUUID, 1)
+func (api API) MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID string) (*MetricsCustomerSubscriptions, error) {
+	result := &MetricsCustomerSubscriptions{}
+	path := strings.Replace(metricsCustomerSubscriptionsEndpoint, ":uuid", customerUUID, 1)
 	query := make([]interface{}, 0, 1)
 	if cursor != nil {
 		query = append(query, *cursor)

--- a/metrics_customer_subscriptions_test.go
+++ b/metrics_customer_subscriptions_test.go
@@ -1,0 +1,61 @@
+package chartmogul
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// Test list activities tests.
+func TestListCustomerSubscriptions(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/customers/cus_8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7/subscriptions" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				//nolint
+				w.Write([]byte(`{"entries": [{
+                                                "id": 9306830,
+                                                "external_id": "sub_0001",
+                                                "plan": "PRO Plan (10,000 active cust.) monthly",
+                                                "quantity": 1,
+                                                "mrr": 70800,
+                                                "arr": 849600,
+                                                "status": "active",
+                                                "billing-cycle": "month",
+                                                "billing-cycle-count": 1,
+                                                "start-date": "2015-12-20T08:26:49-05:00",
+                                                "end-date": "2016-03-20T09:26:49-05:00",
+                                                "currency": "USD",
+                                                "currency-sign": "$"
+                                            }],
+                                "has_more": false,
+                                "per_page": 200,
+                                "page": 1}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		AccountToken: "token",
+		AccessKey:    "key",
+	}
+	activities, err := tested.MetricsListCustomerSubscriptions(&Cursor{}, "cus_8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7")
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if len(activities.Entries) == 0 ||
+		activities.Entries[0].ExternalID != "sub_0001" {
+		spew.Dump(activities)
+		t.Fatal("Unexpected result")
+	}
+}

--- a/metrics_customer_subscriptions_test.go
+++ b/metrics_customer_subscriptions_test.go
@@ -22,23 +22,23 @@ func TestListCustomerSubscriptions(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				//nolint
 				w.Write([]byte(`{"entries": [{
-                                                "id": 9306830,
-                                                "external_id": "sub_0001",
-                                                "plan": "PRO Plan (10,000 active cust.) monthly",
-                                                "quantity": 1,
-                                                "mrr": 70800,
-                                                "arr": 849600,
-                                                "status": "active",
-                                                "billing-cycle": "month",
-                                                "billing-cycle-count": 1,
-                                                "start-date": "2015-12-20T08:26:49-05:00",
-                                                "end-date": "2016-03-20T09:26:49-05:00",
-                                                "currency": "USD",
-                                                "currency-sign": "$"
-                                            }],
-                                "has_more": false,
-                                "per_page": 200,
-                                "page": 1}`))
+									"id": 9306830,
+									"external_id": "sub_0001",
+									"plan": "PRO Plan (10,000 active cust.) monthly",
+									"quantity": 1,
+									"mrr": 70800,
+									"arr": 849600,
+									"status": "active",
+									"billing-cycle": "month",
+									"billing-cycle-count": 1,
+									"start-date": "2015-12-20T08:26:49-05:00",
+									"end-date": "2016-03-20T09:26:49-05:00",
+									"currency": "USD",
+									"currency-sign": "$"
+								}],
+								"has_more": false,
+								"per_page": 200,
+								"page": 1}`))
 			}))
 	defer server.Close()
 	SetURL(server.URL + "/v/%v")

--- a/mock_chartmogul/chartmogul.go
+++ b/mock_chartmogul/chartmogul.go
@@ -474,7 +474,23 @@ func (mr *MockIApiMockRecorder) MergeCustomers(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergeCustomers", reflect.TypeOf((*MockIApi)(nil).MergeCustomers), arg0)
 }
 
-// MetricsListActivities mocks base method
+// MetricsListCustomerActivities mocks base method
+func (m *MockIApi) MetricsListCustomerActivities(arg0 *chartmogul.Cursor, arg1 string) (*chartmogul.MetricsCustomerActivities, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MetricsListCustomerActivities", arg0, arg1)
+	ret0, _ := ret[0].(*chartmogul.MetricsCustomerActivities)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MetricsListCustomerActivities indicates an expected call of MetricsListActivities
+func (mr *MockIApiMockRecorder) MetricsListCustomerActivities(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsListCustomerActivities", reflect.TypeOf((*MockIApi)(nil).MetricsListCustomerActivities), arg0, arg1)
+}
+
+
+// MetricsListCustomerActivities mocks base method
 func (m *MockIApi) MetricsListActivities(arg0 *chartmogul.Cursor, arg1 string) (*chartmogul.MetricsActivities, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsListActivities", arg0, arg1)
@@ -483,25 +499,26 @@ func (m *MockIApi) MetricsListActivities(arg0 *chartmogul.Cursor, arg1 string) (
 	return ret0, ret1
 }
 
-// MetricsListActivities indicates an expected call of MetricsListActivities
+// MetricsListCustomerActivities indicates an expected call of MetricsListActivities
 func (mr *MockIApiMockRecorder) MetricsListActivities(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsListActivities", reflect.TypeOf((*MockIApi)(nil).MetricsListActivities), arg0, arg1)
 }
 
-// MetricsListSubscriptions mocks base method
-func (m *MockIApi) MetricsListSubscriptions(arg0 *chartmogul.Cursor, arg1 string) (*chartmogul.MetricsSubscriptions, error) {
+
+// MetricsListCustomerSubscriptions mocks base method
+func (m *MockIApi) MetricsListCustomerSubscriptions(arg0 *chartmogul.Cursor, arg1 string) (*chartmogul.MetricsCustomerSubscriptions, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MetricsListSubscriptions", arg0, arg1)
-	ret0, _ := ret[0].(*chartmogul.MetricsSubscriptions)
+	ret := m.ctrl.Call(m, "MetricsListCustomerSubscriptions", arg0, arg1)
+	ret0, _ := ret[0].(*chartmogul.MetricsCustomerSubscriptions)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MetricsListSubscriptions indicates an expected call of MetricsListSubscriptions
-func (mr *MockIApiMockRecorder) MetricsListSubscriptions(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockIApiMockRecorder) MetricsListCustomerSubscriptions(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsListSubscriptions", reflect.TypeOf((*MockIApi)(nil).MetricsListSubscriptions), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsListCustomerSubscriptions", reflect.TypeOf((*MockIApi)(nil).MetricsListCustomerSubscriptions), arg0, arg1)
 }
 
 // MetricsRetrieveARPA mocks base method

--- a/mock_chartmogul/chartmogul.go
+++ b/mock_chartmogul/chartmogul.go
@@ -483,7 +483,6 @@ func (m *MockIApi) MetricsListCustomerActivities(arg0 *chartmogul.Cursor, arg1 s
 	return ret0, ret1
 }
 
-// MetricsListCustomerActivities indicates an expected call of MetricsListActivities
 func (mr *MockIApiMockRecorder) MetricsListCustomerActivities(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsListCustomerActivities", reflect.TypeOf((*MockIApi)(nil).MetricsListCustomerActivities), arg0, arg1)


### PR DESCRIPTION
This PR supports the new v1/activities end point under Metrics API. We want the libraries to serve the results from `v1/activities` under `api.MetricsListCustomerActivities` namespace. However this namespace has already been taken up by customer scoped activities serving results from `v1/customers/CUSTOMER_UUID/activities` endpoint

In order to support both customer scoped activities and unscoped activities, we have decided to introduce new namespaces 

The following are the breaking changes to existing namespaces
```
api.MetricsListSubscriptions  Moves to api.MetricsListCustomerSubscriptions
```
```
api.MetricsListActivities Moves to api.MetricsListCustomerActivities
```
```
The v1/activities will be mapped to "api.MetricsListActivities" namespace.
This will include support for anchored pagination option param "start_after". 
```

The gem will get a bump in major version as this is a breaking change.