### PR TITLE
Implement support for async activities export

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,10 @@ api.MetricsListCustomerSubscriptions(&Cursor{}, "customerUUID")
 api.MetricsListCustomerActivities(&Cursor{}, "customerUUID")
 
 api.MetricsListActivities(&cm.MetricsListActivitiesParams{StartDate: "2016-09-16T09:28:10Z", AnchorCursor: cm.AnchorCursor{PerPage: 5, StartAfter: "b45b1d3f-3823-424f-ab47-5a1d0c00a7f6"}})
-```
 
+api.MetricsCreateActivitiesExport(&cm.ActivitiesExport{})
+api.MetricsRetrieveActivitesExport("activitiesExportUUID")
+```
 
 ### Account
 

--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ api.MetricsRetrieveLTV(&MetricsFilter{})
 api.MetricsListCustomerSubscriptions(&Cursor{}, "customerUUID")
 api.MetricsListCustomerActivities(&Cursor{}, "customerUUID")
 
-api.MetricsListActivities(&cm.MetricsListActivitiesParams{StartDate: "2016-09-16T09:28:10Z", AnchorCursor: cm.AnchorCursor{PerPage: 5, StartAfter: "b45b1d3f-3823-424f-ab47-5a1d0c00a7f6"}})
+api.MetricsListActivities(&cm.MetricsListActivitiesParams{StartDate: "2016-09-16", AnchorCursor: cm.AnchorCursor{PerPage: 5, StartAfter: "b45b1d3f-3823-424f-ab47-5a1d0c00a7f6"}})
 
-api.MetricsCreateActivitiesExport(&cm.NewMetricsActivitiesExport{StartDate: "2016-09-16T09:28:10Z",Type: "contraction"})
+api.MetricsCreateActivitiesExport(&cm.CreateMetricsActivitiesExportParam{StartDate: "2016-09-16",Type: "contraction"})
 api.MetricsRetrieveActivitiesExport("activitiesExportUUID")
 ```
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ api.MetricsListCustomerActivities(&Cursor{}, "customerUUID")
 api.MetricsListActivities(&cm.MetricsListActivitiesParams{StartDate: "2016-09-16T09:28:10Z", AnchorCursor: cm.AnchorCursor{PerPage: 5, StartAfter: "b45b1d3f-3823-424f-ab47-5a1d0c00a7f6"}})
 
 api.MetricsCreateActivitiesExport(&cm.NewMetricsActivitiesExport{StartDate: "2016-09-16T09:28:10Z",Type: "contraction"})
-api.MetricsRetrieveActivitesExport("activitiesExportUUID")
+api.MetricsRetrieveActivitiesExport("activitiesExportUUID")
 ```
 
 ### Account

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ api.MetricsListCustomerActivities(&Cursor{}, "customerUUID")
 
 api.MetricsListActivities(&cm.MetricsListActivitiesParams{StartDate: "2016-09-16T09:28:10Z", AnchorCursor: cm.AnchorCursor{PerPage: 5, StartAfter: "b45b1d3f-3823-424f-ab47-5a1d0c00a7f6"}})
 
-api.MetricsCreateActivitiesExport(&cm.ActivitiesExport{})
+api.MetricsCreateActivitiesExport(&cm.NewMetricsActivitiesExport{StartDate: "2016-09-16T09:28:10Z",Type: "contraction"})
 api.MetricsRetrieveActivitesExport("activitiesExportUUID")
 ```
 

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -125,6 +125,8 @@ type IApi interface {
 	MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID string) (*MetricsCustomerSubscriptions, error)
 	MetricsListCustomerActivities(cursor *Cursor, customerUUID string) (*MetricsCustomerActivities, error)
 	MetricsListActivities(MetricsListActivitiesParams *MetricsListActivitiesParams) (*MetricsActivities, error)
+	MetricsCreateActivitiesExport(NewMetricsActivitiesExport *NewMetricsActivitiesExport) (*MetricsActivitiesExport, error)
+	MetricsRetrieveActivitiesExport(activitiesExportUUID string) (*MetricsActivitiesExport, error)
 
 	// Account
 	RetrieveAccount() (*Account, error)

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -125,7 +125,7 @@ type IApi interface {
 	MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID string) (*MetricsCustomerSubscriptions, error)
 	MetricsListCustomerActivities(cursor *Cursor, customerUUID string) (*MetricsCustomerActivities, error)
 	MetricsListActivities(MetricsListActivitiesParams *MetricsListActivitiesParams) (*MetricsActivities, error)
-	MetricsCreateActivitiesExport(NewMetricsActivitiesExport *NewMetricsActivitiesExport) (*MetricsActivitiesExport, error)
+	MetricsCreateActivitiesExport(CreateMetricsActivitiesExportParam *CreateMetricsActivitiesExportParam) (*MetricsActivitiesExport, error)
 	MetricsRetrieveActivitiesExport(activitiesExportUUID string) (*MetricsActivitiesExport, error)
 
 	// Account

--- a/metrics_activities_exports.go
+++ b/metrics_activities_exports.go
@@ -2,24 +2,23 @@ package chartmogul
 
 // MetricsActivitiesExport represents Metrics API activity export in ChartMogul.
 type MetricsActivitiesExport struct {
-	ID                   	  string `json:"id"`
-	Status                  string `json:"status"`
-	FileURL            			string `json:"file_url"`
-	Params		            	Params `json:"params"`
-	ExpiresAt    						string `json:"expires_at"`
-	CreatedAt               string `json:"created_at"`
-
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	FileURL   string `json:"file_url"`
+	Params    Params `json:"params"`
+	ExpiresAt string `json:"expires_at"`
+	CreatedAt string `json:"created_at"`
 }
 
 type Params struct {
-	Kind string `json:"kind"`
+	Kind   string       `json:"kind"`
 	Params NestedParams `json:"params,omitempty"`
 }
 
 type NestedParams struct {
 	ActivityType string `json:"activity_type,omitempty"`
-	StartDate string `json:"start-date,omitempty"`
-	EndDate   string `json:"end-date,omitempty"`
+	StartDate    string `json:"start-date,omitempty"`
+	EndDate      string `json:"end-date,omitempty"`
 }
 
 // NewMetricsActivitiesExport is the POST-ed to create a MetricsActivitiesExport .
@@ -30,7 +29,7 @@ type NewMetricsActivitiesExport struct {
 }
 
 const (
-	metricsActivitiesExportEndpoint = "activities_export"
+	metricsActivitiesExportEndpoint       = "activities_export"
 	singleMetricsActivitiesExportEndpoint = "activities_export/:activities_export_uuid"
 )
 

--- a/metrics_activities_exports.go
+++ b/metrics_activities_exports.go
@@ -9,20 +9,21 @@ type MetricsActivitiesExport struct {
 	ExpiresAt string `json:"expires_at"`
 	CreatedAt string `json:"created_at"`
 }
-
+// Params provides information on the equested export.
 type Params struct {
 	Kind   string       `json:"kind"`
 	Params NestedParams `json:"params,omitempty"`
 }
 
+// NestedParams represents the params of the requested type of export.
 type NestedParams struct {
 	ActivityType string `json:"activity_type,omitempty"`
 	StartDate    string `json:"start_date,omitempty"`
 	EndDate      string `json:"end_date,omitempty"`
 }
 
-// NewMetricsActivitiesExport is the POST-ed to create a MetricsActivitiesExport .
-type NewMetricsActivitiesExport struct {
+// CreateMetricsActivitiesExportParam is the POST-ed to create a MetricsActivitiesExport.
+type CreateMetricsActivitiesExportParam struct {
 	Type      string `json:"type,omitempty"`
 	StartDate string `json:"start-date,omitempty"`
 	EndDate   string `json:"end-date,omitempty"`
@@ -36,9 +37,9 @@ const (
 // MetricsCreateActivitiesExport requests creation of an activities export in Chartmogul.
 //
 // See https://dev.chartmogul.com/v1.0/reference#activities_export
-func (api API) MetricsCreateActivitiesExport(NewMetricsActivitiesExport *NewMetricsActivitiesExport) (*MetricsActivitiesExport, error) {
+func (api API) MetricsCreateActivitiesExport(CreateMetricsActivitiesExportParam *CreateMetricsActivitiesExportParam) (*MetricsActivitiesExport, error) {
 	result := &MetricsActivitiesExport{}
-	return result, api.create(metricsActivitiesExportEndpoint, NewMetricsActivitiesExport, result)
+	return result, api.create(metricsActivitiesExportEndpoint, CreateMetricsActivitiesExportParam, result)
 }
 
 // MetricsRetrieveActivitiesExport returns one activities export as in API.

--- a/metrics_activities_exports.go
+++ b/metrics_activities_exports.go
@@ -1,0 +1,51 @@
+package chartmogul
+
+// MetricsActivitiesExport represents Metrics API activity export in ChartMogul.
+type MetricsActivitiesExport struct {
+	ID                   	  string `json:"id"`
+	Status                  string `json:"status"`
+	FileURL            			string `json:"file_url"`
+	Params		            	Params `json:"params"`
+	ExpiresAt    						string `json:"expires_at"`
+	CreatedAt               string `json:"created_at"`
+
+}
+
+type Params struct {
+	Kind string `json:"kind"`
+	Params NestedParams `json:"params,omitempty"`
+}
+
+type NestedParams struct {
+	ActivityType string `json:"activity_type,omitempty"`
+	StartDate string `json:"start-date,omitempty"`
+	EndDate   string `json:"end-date,omitempty"`
+}
+
+// NewMetricsActivitiesExport is the POST-ed to create a MetricsActivitiesExport .
+type NewMetricsActivitiesExport struct {
+	Type      string `json:"type,omitempty"`
+	StartDate string `json:"start-date,omitempty"`
+	EndDate   string `json:"end-date,omitempty"`
+}
+
+const (
+	metricsActivitiesExportEndpoint = "activities_export"
+	singleMetricsActivitiesExportEndpoint = "activities_export/:activities_export_uuid"
+)
+
+// MetricsCreateActivitiesExport requests creation of an activities export in Chartmogul.
+//
+// See https://dev.chartmogul.com/v1.0/reference#activities_export
+func (api API) MetricsCreateActivitiesExport(NewMetricsActivitiesExport *NewMetricsActivitiesExport) (*MetricsActivitiesExport, error) {
+	result := &MetricsActivitiesExport{}
+	return result, api.create(metricsActivitiesExportEndpoint, NewMetricsActivitiesExport, result)
+}
+
+// MetricsRetrieveActivitiesExport returns one activities export as in API.
+//
+// See https://dev.chartmogul.com/v1.0/reference#activities_export
+func (api API) MetricsRetrieveActivitiesExport(activitiesExportUUID string) (*MetricsActivitiesExport, error) {
+	result := &MetricsActivitiesExport{}
+	return result, api.retrieve(singleMetricsActivitiesExportEndpoint, activitiesExportUUID, result)
+}

--- a/metrics_activities_exports.go
+++ b/metrics_activities_exports.go
@@ -9,7 +9,7 @@ type MetricsActivitiesExport struct {
 	ExpiresAt string `json:"expires_at"`
 	CreatedAt string `json:"created_at"`
 }
-// Params provides information on the equested export.
+// Params provides information on the requested export.
 type Params struct {
 	Kind   string       `json:"kind"`
 	Params NestedParams `json:"params,omitempty"`
@@ -22,7 +22,7 @@ type NestedParams struct {
 	EndDate      string `json:"end_date,omitempty"`
 }
 
-// CreateMetricsActivitiesExportParam is the POST-ed to create a MetricsActivitiesExport.
+// CreateMetricsActivitiesExportParam to create a MetricsActivitiesExport.
 type CreateMetricsActivitiesExportParam struct {
 	Type      string `json:"type,omitempty"`
 	StartDate string `json:"start-date,omitempty"`

--- a/metrics_activities_exports.go
+++ b/metrics_activities_exports.go
@@ -9,6 +9,7 @@ type MetricsActivitiesExport struct {
 	ExpiresAt string `json:"expires_at"`
 	CreatedAt string `json:"created_at"`
 }
+
 // Params provides information on the requested export.
 type Params struct {
 	Kind   string       `json:"kind"`

--- a/metrics_activities_exports.go
+++ b/metrics_activities_exports.go
@@ -17,8 +17,8 @@ type Params struct {
 
 type NestedParams struct {
 	ActivityType string `json:"activity_type,omitempty"`
-	StartDate    string `json:"start-date,omitempty"`
-	EndDate      string `json:"end-date,omitempty"`
+	StartDate    string `json:"start_date,omitempty"`
+	EndDate      string `json:"end_date,omitempty"`
 }
 
 // NewMetricsActivitiesExport is the POST-ed to create a MetricsActivitiesExport .
@@ -30,7 +30,7 @@ type NewMetricsActivitiesExport struct {
 
 const (
 	metricsActivitiesExportEndpoint       = "activities_export"
-	singleMetricsActivitiesExportEndpoint = "activities_export/:activities_export_uuid"
+	singleMetricsActivitiesExportEndpoint = "activities_export/:uuid"
 )
 
 // MetricsCreateActivitiesExport requests creation of an activities export in Chartmogul.

--- a/metrics_activities_exports_test.go
+++ b/metrics_activities_exports_test.go
@@ -1,0 +1,111 @@
+package chartmogul
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// Tests creation on an activity export.
+func TestCreateActivitiesExport(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "POST" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/activities_export" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				//nolint
+				w.Write([]byte(`{
+							      "id": "7f554dba-4a41-4cb2-9790-2045e4c3a5b1",
+							      "status": "pending",
+							      "file_url": null,
+							      "params": {
+							        "kind": "activities",
+							        "params": {
+							          "activity_type": "contraction",
+							          "start_date": "2020-01-01",
+							          "end_date": "2020-12-31"
+							        }
+							      },
+							      "expires_at": null,
+							      "created_at": "2021-07-12T14:46:56+00:00"
+							    }`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		AccountToken: "token",
+		AccessKey:    "key",
+	}
+	activities_export, err := tested.MetricsCreateActivitiesExport(&NewMetricsActivitiesExport{
+		StartDate: "2020-01-01",
+		EndDate: 	 "2020-12-31",
+		Type: 		 "contraction",
+	})
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if activities_export.ID != "7f554dba-4a41-4cb2-9790-2045e4c3a5b1" || activities_export.Status != "pending" {
+		spew.Dump(activities_export)
+		t.Fatal("Unexpected result")
+	}
+}
+
+// Tests retrieval of an activity export
+func TestRetrieveActivitiesExport(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/activities_export/:activities_export_uuid" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				//nolint
+				w.Write([]byte(`{
+							      "id": "7f554dba-4a41-4cb2-9790-2045e4c3a5b1",
+							      "status": "succeeded",
+							      "file_url": "https://chartmogul-customer-export.s3.eu-west-1.amazonaws.com/activities-acme-corp-91e1ca88-d747-4e25-83d9-2b752033bdba.zip",
+							      "params": {
+							        "kind": "activities",
+							        "params": {
+							          "activity_type": "contraction",
+							          "start_date": "2020-01-01",
+							          "end_date": "2020-12-31"
+							        }
+							      },
+							      "expires_at": "2021-07-19T14:46:58+00:00",
+							      "created_at": "2021-07-12T14:46:56+00:00"
+							    }`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		AccountToken: "token",
+		AccessKey:    "key",
+	}
+
+	var activities_export_id = "7f554dba-4a41-4cb2-9790-2045e4c3a5b1"
+	activities_export, err := tested.MetricsRetrieveActivitiesExport(activities_export_id)
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if activities_export.ID != activities_export_id || activities_export.Status != "succeeded" {
+		spew.Dump(activities_export)
+		t.Fatal("Unexpected result")
+	}
+}

--- a/metrics_activities_exports_test.go
+++ b/metrics_activities_exports_test.go
@@ -97,14 +97,14 @@ func TestRetrieveActivitiesExport(t *testing.T) {
 		AccessKey:    "key",
 	}
 
-	var activitiesExportId = "7f554dba-4a41-4cb2-9790-2045e4c3a5b1"
-	activitiesExport, err := tested.MetricsRetrieveActivitiesExport(activitiesExportId)
+	var activitiesExportID = "7f554dba-4a41-4cb2-9790-2045e4c3a5b1"
+	activitiesExport, err := tested.MetricsRetrieveActivitiesExport(activitiesExportID)
 
 	if err != nil {
 		spew.Dump(err)
 		t.Fatal("Not expected to fail")
 	}
-	if activitiesExport.ID != activitiesExportId || activitiesExport.Status != "succeeded" {
+	if activitiesExport.ID != activitiesExportID || activitiesExport.Status != "succeeded" {
 		spew.Dump(activitiesExport)
 		t.Fatal("Unexpected result")
 	}

--- a/metrics_activities_exports_test.go
+++ b/metrics_activities_exports_test.go
@@ -68,7 +68,7 @@ func TestRetrieveActivitiesExport(t *testing.T) {
 				if r.Method != "GET" {
 					t.Errorf("Unexpected method %v", r.Method)
 				}
-				if r.RequestURI != "/v/activities_export/:activities_export_uuid" {
+				if r.RequestURI != "/v/activities_export/7f554dba-4a41-4cb2-9790-2045e4c3a5b1" {
 					t.Errorf("Unexpected URI %v", r.RequestURI)
 				}
 				w.WriteHeader(http.StatusOK)

--- a/metrics_activities_exports_test.go
+++ b/metrics_activities_exports_test.go
@@ -44,7 +44,7 @@ func TestCreateActivitiesExport(t *testing.T) {
 		AccountToken: "token",
 		AccessKey:    "key",
 	}
-	activities_export, err := tested.MetricsCreateActivitiesExport(&NewMetricsActivitiesExport{
+	activitiesExport, err := tested.MetricsCreateActivitiesExport(&CreateMetricsActivitiesExportParam{
 		StartDate: "2020-01-01",
 		EndDate:   "2020-12-31",
 		Type:      "contraction",
@@ -54,8 +54,8 @@ func TestCreateActivitiesExport(t *testing.T) {
 		spew.Dump(err)
 		t.Fatal("Not expected to fail")
 	}
-	if activities_export.ID != "7f554dba-4a41-4cb2-9790-2045e4c3a5b1" || activities_export.Status != "pending" {
-		spew.Dump(activities_export)
+	if activitiesExport.ID != "7f554dba-4a41-4cb2-9790-2045e4c3a5b1" || activitiesExport.Status != "pending" {
+		spew.Dump(activitiesExport)
 		t.Fatal("Unexpected result")
 	}
 }
@@ -97,15 +97,15 @@ func TestRetrieveActivitiesExport(t *testing.T) {
 		AccessKey:    "key",
 	}
 
-	var activities_export_id = "7f554dba-4a41-4cb2-9790-2045e4c3a5b1"
-	activities_export, err := tested.MetricsRetrieveActivitiesExport(activities_export_id)
+	var activitiesExportId = "7f554dba-4a41-4cb2-9790-2045e4c3a5b1"
+	activitiesExport, err := tested.MetricsRetrieveActivitiesExport(activitiesExportId)
 
 	if err != nil {
 		spew.Dump(err)
 		t.Fatal("Not expected to fail")
 	}
-	if activities_export.ID != activities_export_id || activities_export.Status != "succeeded" {
-		spew.Dump(activities_export)
+	if activitiesExport.ID != activitiesExportId || activitiesExport.Status != "succeeded" {
+		spew.Dump(activitiesExport)
 		t.Fatal("Unexpected result")
 	}
 }

--- a/metrics_activities_exports_test.go
+++ b/metrics_activities_exports_test.go
@@ -46,8 +46,8 @@ func TestCreateActivitiesExport(t *testing.T) {
 	}
 	activities_export, err := tested.MetricsCreateActivitiesExport(&NewMetricsActivitiesExport{
 		StartDate: "2020-01-01",
-		EndDate: 	 "2020-12-31",
-		Type: 		 "contraction",
+		EndDate:   "2020-12-31",
+		Type:      "contraction",
 	})
 
 	if err != nil {


### PR DESCRIPTION
This PR provides support for a new async activities export with optional params for start date, end date and activity type.

```
	activities_export, err := api.MetricsCreateActivitiesExport(&NewMetricsActivitiesExport{
		StartDate: "2020-01-01",
		EndDate:   "2020-12-31",
		Type:      "contraction",
	})
```

Initially, the export will have the status `pending` and a `nil` file_url. After a period of time, the async job will complete and the status will update to `processing` and then `succeeded` or `failed`. In the case of `succeeded`, the `file_url` will be populated with the url with the zipped activities export.

A user of the client library could schedule a job with the ID of the export, so they can periodically check it until it reaches  `succeeded` or `failed`.

If you have the uuid of the export, you can retrieve it via:

```
var activities_export_id = "7f554dba-4a41-4cb2-9790-2045e4c3a5b1"
activities_export, err := api.MetricsRetrieveActivitiesExport(activities_export_id)
```
