### PR TITLE
Change Customers type to be uint32 [sc41717]

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -54,8 +54,8 @@ type AllSummary struct {
     CurrentLtv                          float64 `json:"current-ltv"`
     PreviousLtv                         float64 `json:"previous-ltv"`
     LtvPercentageChange                 float64 `json:"ltv-percentage-change"`
-    CurrentCustomers                    float64 `json:"current-customers"`
-    PreviousCustomers                   float64 `json:"previous-customers"`
+    CurrentCustomers                    uint32 `json:"current-customers"`
+    PreviousCustomers                   uint32 `json:"previous-customers"`
     CustomersPercentageChange           float64 `json:"customers-percentage-change"`
     CurrentAsp                          float64 `json:"current-asp"`
     PreviousAsp                         float64 `json:"previous-asp"`


### PR DESCRIPTION
By mistake used float64 instead of uint32 for `CurrentCustomers` and `PreviousCustomers`, when for `Customers` we used https://github.com/chartmogul/chartmogul-go/blob/e0bdb4f9bd8ea3220855e9afa0ae882053284df8/metrics.go#L18 uint32.