### PR TITLE
include UUID in MetricsCustomerSubscription

### DIFF
--- a/metrics_customer_subscriptions.go
+++ b/metrics_customer_subscriptions.go
@@ -6,6 +6,7 @@ import "strings"
 type MetricsCustomerSubscription struct {
 	ID                uint64  `json:"id"`
 	ExternalID        string  `json:"external_id"`
+	UUID              string  `json:"uuid"`
 	Plan              string  `json:"plan"`
 	Quantity          uint32  `json:"quantity"`
 	BillingCycleCount uint32  `json:"billing-cycle-count"`


### PR DESCRIPTION
## About this change
Include `uuid` in `MetricsCustomerSubscription` struct

## Why change
UUID is needed for further operations like connect subscriptions. Import API returns UUID in subscriptions but import api won't include webhook integration subscriptions like recurly.