### PR TITLE
Add Tasks API support to Go Client [sc-66754]

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Note: the `Ping` doesn't retry.
 
 Available methods in Import API:
 
-#### [Data Sources](https://dev.chartmogul.com/docs/data-sources)
+#### [Data Sources](https://dev.chartmogul.com/reference/sources/)
 
 ```go
 api.CreateDataSource("name")
@@ -99,7 +99,7 @@ api.RetrieveDataSource("uuid")
 api.DeleteDataSource("uuid")
 ```
 
-#### [Customers](https://dev.chartmogul.com/docs/retrieve-customer)
+#### [Customers](https://dev.chartmogul.com/reference/customers/)
 
 ```go
 api.CreateCustomer(&cm.NewCustomer{})
@@ -117,9 +117,11 @@ api.ListCustomerNotes(&cm.ListNotesParams{}, "customerUUID")
 api.CreateCustomerNote(&cm.NewNote{}, "customerUUID")
 api.ListCustomerOpportunities(&cm.ListOpportunitiesParams{}, "customerUUID")
 api.CreateCustomerOpportunity(&cm.NewOpportunity{}, "customerUUID")
+api.ListCustomerTasks(&cm.ListTasksParams{}, "customerUUID")
+api.CreateCustomerTask(&cm.NewTask{}, "customerUUID")
 ```
 
-#### [Contacts](https://dev.chartmogul.com/reference/contacts)
+#### [Contacts](https://dev.chartmogul.com/reference/contacts/)
 
 ```go
 api.CreateContact(&cm.NewContact{})
@@ -130,7 +132,7 @@ api.DeleteContact("customerUUID")
 api.MergeContacts("intoContactUUID", "fromContactUUID")
 ```
 
-#### [Customer Notes](https://dev.chartmogul.com/reference/customer-notes)
+#### [Customer Notes](https://dev.chartmogul.com/reference/notes-and-call-logs/)
 
 ```go
 api.CreateNote(&cm.NewNote{})
@@ -140,7 +142,7 @@ api.UpdateNote(&cm.UpdateNote{}, "noteUUID")
 api.DeleteNote("noteUUID")
 ```
 
-#### [Opportunities](https://dev.chartmogul.com/reference/opportunities)
+#### [Opportunities](https://dev.chartmogul.com/reference/opportunities/)
 
 ```go
 api.CreateOpportunity(&cm.NewOpportunity{})
@@ -150,7 +152,17 @@ api.UpdateOpportunity(&cm.UpdateOpportunity{}, "opportunityUUID")
 api.DeleteOpportunity("opportunityUUID")
 ```
 
-#### [Plans](https://dev.chartmogul.com/reference#plans)
+#### [Tasks](https://dev.chartmogul.com/reference/tasks/)
+
+```go
+api.CreateTask(&cm.NewTask{})
+api.RetrieveTask("taskUUID")
+api.ListTask(&cm.ListTaskParams{})
+api.UpdateTask(&cm.UpdateTask{}, "taskUUID")
+api.DeleteTask("taskUUID")
+```
+
+#### [Plans](https://dev.chartmogul.com/reference/plans/)
 
 ```go
 api.CreatePlan(&cm.Plan{Name: "name", ExternalID: "external_id"}, "dataSourceUUID")
@@ -160,7 +172,7 @@ api.UpdatePlan(&cm.Plan{}, "planUUID")
 api.DeletePlan("planUUID")
 ```
 
-#### [Plan Groups](https://dev.chartmogul.com/reference#plan_groups)
+#### [Plan Groups](https://dev.chartmogul.com/reference/plan-groups/)
 
 ```go
 api.CreatePlanGroup(&cm.PlanGroup{Name: "name", Plans: []*string{&planOne.UUID, &planTwo.UUID}})
@@ -171,7 +183,7 @@ api.DeletePlanGroup("planGroupUUID")
 api.ListPlanGroupPlans(&cm.ListPlansParams{Cursor: cm.Cursor{PerPage: "10"}},  "planGroupUUID")
 ```
 
-#### [Invoices](https://dev.chartmogul.com/docs/invoices)
+#### [Invoices](https://dev.chartmogul.com/reference/invoices/)
 
 ```go
 api.CreateInvoices([]*cm.Invoice{*cm.Invoice{}}, "customerUUID")
@@ -181,13 +193,13 @@ api.RetrieveInvoice("invoiceUUID")
 api.DeleteInvoice("invoiceUUID")
 ```
 
-#### [Transactions](https://dev.chartmogul.com/docs/transactions)
+#### [Transactions](https://dev.chartmogul.com/reference/transactions/)
 
 ```go
 api.CreateTransaction(&cm.Transaction{}, "invoiceUUID")
 ```
 
-#### [Subscriptions](https://dev.chartmogul.com/docs/subscriptions)
+#### [Subscriptions](https://dev.chartmogul.com/reference/subscriptions/)
 
 ```go
 api.CancelSubscription("subscriptionUUID", &cm.CancelSubscriptionParams{CancelledAt: "2005-01-01T01:02:03.000Z"})
@@ -195,13 +207,13 @@ api.CancelSubscription("subscriptionUUID", &cm.CancelSubscriptionParams{Cancella
 api.ListSubscriptions(&cm.Cursor{}, "customerUUID")
 ```
 
-#### [Customer Attributes](https://dev.chartmogul.com/docs/customer-attributes)
+#### [Customer Attributes](https://dev.chartmogul.com/reference/customers/attributes/)
 
 ```go
 api.RetrieveCustomersAttributes("customerUUID")
 ```
 
-#### [Tags](https://dev.chartmogul.com/docs/tags)
+#### [Tags](https://dev.chartmogul.com/reference/customers/tags/)
 
 ```go
 api.AddTagsToCustomer("customerUUID", []string{})
@@ -209,13 +221,13 @@ api.AddTagsToCustomersWithEmail("email@customer.com", []string{})
 ```
 
 
-#### [Custom Attributes](https://dev.chartmogul.com/docs/custom-attributes)
+#### [Custom Attributes](https://dev.chartmogul.com/reference/customers/attributes/)
 
 ```go
 api.AddCustomAttributesToCustomer("customerUUID", []*cm.CustomAttribute{})
 ```
 
-#### [Subscription Events](https://dev.chartmogul.com/reference/subscription-events)
+#### [Subscription Events](https://dev.chartmogul.com/reference/subscription-events/)
 ```go
 api.ListSubscriptionEvents(filters *FilterSubscriptionEvents, cursor *Cursor)
 api.CreateSubscriptionEvent(newSubscriptionEvent *SubscriptionEvent)
@@ -223,7 +235,7 @@ api.UpdateSubscriptionEvent(subscriptionEvent *SubscriptionEvent)
 api.DeleteSubscriptionEvent(deleteParams *DeleteSubscriptionEvent)
 ```
 
-### [Metrics API](https://dev.chartmogul.com/docs/introduction-metrics-api)
+### [Metrics API](https://dev.chartmogul.com/reference/metrics/)
 
 Available methods in Metrics API:
 

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -99,6 +99,8 @@ type IApi interface {
 	CreateCustomersContact(newContact *NewContact, customerUUID string) (*Contact, error)
 	ListCustomerNotes(ListNotesParams *ListNotesParams, customerUUID string) (*Notes, error)
 	CreateCustomerNote(newCustomerNote *NewNote, customerUUID string) (*Note, error)
+	ListCustomerTasks(ListTasksParams *ListTasksParams, customerUUID string) (*Tasks, error)
+	CreateCustomerTask(newCustomerTask *NewTask, customerUUID string) (*Task, error)
 
 	// Contacts
 	CreateContact(newContact *NewContact) (*Contact, error)
@@ -114,6 +116,13 @@ type IApi interface {
 	UpdateNote(Note *UpdateNote, noteUUID string) (*Note, error)
 	DeleteNote(noteUUID string) error
 	ListNotes(ListNotesParams *ListNotesParams) (*Notes, error)
+
+	// Tasks
+	CreateTask(newTask *NewTask) (*Task, error)
+	RetrieveTask(taskUUID string) (*Task, error)
+	UpdateTask(Task *UpdateTask, taskUUID string) (*Task, error)
+	ListTasks(ListTasksParams *ListTasksParams) (*Tasks, error)
+	DeleteTask(taskUUID string) error
 
 	//  - Cusomer Attributes
 	RetrieveCustomersAttributes(customerUUID string) (*Attributes, error)

--- a/customers.go
+++ b/customers.go
@@ -328,3 +328,29 @@ func (api API) CreateCustomerOpportunity(input *NewOpportunity, customerUUID str
 	}
 	return result, api.create(opportunitiesEndpoint, input, result)
 }
+
+// ListCustomerTasks
+//
+// See https://dev.chartmogul.com/reference/tasks/list/
+func (api API) ListCustomerTasks(listTasksParams *ListTasksParams, customerUUID string) (*Tasks, error) {
+	result := &Tasks{}
+	query := make([]interface{}, 0, 1)
+	if listTasksParams != nil {
+		if listTasksParams.CustomerUUID == "" {
+			listTasksParams.CustomerUUID = customerUUID
+		}
+		query = append(query, *listTasksParams)
+	}
+	return result, api.list(tasksEndpoint, result, query...)
+}
+
+// CreateCustomerTask
+//
+// See https://dev.chartmogul.com/reference/tasks/add/
+func (api API) CreateCustomerTask(input *NewTask, customerUUID string) (*Task, error) {
+	result := &Task{}
+	if input.CustomerUUID == "" {
+		input.CustomerUUID = customerUUID
+	}
+	return result, api.create(tasksEndpoint, input, result)
+}

--- a/customers_test.go
+++ b/customers_test.go
@@ -664,7 +664,7 @@ func TestListCustomerTasks(t *testing.T) {
 					"entries": [{
 						"task_uuid": "00000000-0000-0000-0000-000000000000",
 						"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
-						"assignee": "Customer (customer@example.com)",
+						"assignee": "keith+test1@chartmogul.com",
 						"task_details": "This is some task details text.",
 						"due_date": "2025-04-30T00:00:00Z",
 						"completed_at": "2025-04-20T00:00:00Z",
@@ -710,7 +710,7 @@ func TestCreateCustomerTask(t *testing.T) {
 				w.Write([]byte(`{
 					"task_uuid": "00000000-0000-0000-0000-000000000000",
 					"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
-					"assignee": "Customer (customer@example.com)",
+					"assignee": "keith+test1@chartmogul.com",
 					"task_details": "This is some task details text.",
 					"due_date": "2025-04-30T00:00:00Z",
 					"completed_at": "2025-04-20T00:00:00Z",
@@ -726,7 +726,7 @@ func TestCreateCustomerTask(t *testing.T) {
 	}
 
 	task, err := tested.CreateCustomerTask(&NewTask{
-		Assignee:    "customer@example.com",
+		Assignee:    "keith+test1@chartmogul.com",
 		TaskDetails: "This is some task details text.",
 		DueDate:     "2025-04-30T00:00:00Z",
 		CompletedAt: "2025-04-20T00:00:00Z",

--- a/customers_test.go
+++ b/customers_test.go
@@ -647,3 +647,97 @@ func TestCreateCustomerOpportunity(t *testing.T) {
 		t.Fatal("Unexpected result")
 	}
 }
+
+func TestListCustomerTasks(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/tasks?customer_uuid=cus_00000000-0000-0000-0000-000000000000&per_page=1" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				//nolint
+				w.Write([]byte(`{
+					"entries": [{
+						"task_uuid": "00000000-0000-0000-0000-000000000000",
+						"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+						"assignee": "Customer (customer@example.com)",
+						"task_details": "This is some task details text.",
+						"due_date": "2025-04-30T00:00:00Z",
+						"completed_at": "2025-04-20T00:00:00Z",
+						"created_at": "2025-04-01T12:00:00.000Z",
+						"updated_at": "2025-04-01T12:00:00.000Z"
+					}],
+					"has_more": false,
+					"cursor": "88abf99"
+				}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+	}
+	uuid := "cus_00000000-0000-0000-0000-000000000000"
+	params := &ListTasksParams{Cursor: Cursor{PerPage: 1}}
+	tasks, err := tested.ListCustomerTasks(params, uuid)
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if len(tasks.Entries) == 0 {
+		spew.Dump(tasks)
+		t.Fatal("Unexpected result")
+	}
+}
+
+func TestCreateCustomerTask(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "POST" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/tasks" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusCreated)
+				//nolint
+				w.Write([]byte(`{
+					"task_uuid": "00000000-0000-0000-0000-000000000000",
+					"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+					"assignee": "Customer (customer@example.com)",
+					"task_details": "This is some task details text.",
+					"due_date": "2025-04-30T00:00:00Z",
+					"completed_at": "2025-04-20T00:00:00Z",
+					"created_at": "2025-04-01T12:00:00.000Z",
+					"updated_at": "2025-04-01T12:00:00.000Z"
+				}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+	}
+
+	task, err := tested.CreateCustomerTask(&NewTask{
+		Assignee:    "customer@example.com",
+		TaskDetails: "This is some task details text.",
+		DueDate:     "2025-04-30T00:00:00Z",
+		CompletedAt: "2025-04-20T00:00:00Z",
+	}, "cus_00000000-0000-0000-0000-000000000000")
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if task.UUID != "00000000-0000-0000-0000-000000000000" {
+		spew.Dump(task)
+		t.Fatal("Unexpected result")
+	}
+}

--- a/integration_tests/fixtures/tasks.yaml
+++ b/integration_tests/fixtures/tasks.yaml
@@ -1,0 +1,291 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"name":"Test Tasks"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - chartmogul-go/v4
+    url: https://api.chartmogul.com/v1/data_sources
+    method: POST
+  response:
+    body: '{"uuid":"ds_0629fa9a-2006-11f0-ad7b-cfb392f9e98a","name":"Test Tasks","system":"Import
+      API","created_at":"2025-04-23T05:44:29.362Z","status":"idle"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "148"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Apr 2025 05:44:29 GMT
+      Retry-Count:
+      - "0"
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"data_source_uuid":"ds_0629fa9a-2006-11f0-ad7b-cfb392f9e98a","external_id":"ext_customer_1","name":"Test
+      Tasks"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - chartmogul-go/v4
+    url: https://api.chartmogul.com/v1/customers
+    method: POST
+  response:
+    body: '{"id":217637584,"uuid":"cus_0668b1c2-2006-11f0-ad7c-536cb08c2a76","external_id":"ext_customer_1","name":"Test
+      Tasks","email":"","status":"New Lead","customer-since":null,"attributes":{"custom":{},"stripe":{},"tags":[]},"data_source_uuid":"ds_0629fa9a-2006-11f0-ad7b-cfb392f9e98a","data_source_uuids":["ds_0629fa9a-2006-11f0-ad7b-cfb392f9e98a"],"external_ids":["ext_customer_1"],"company":"","country":null,"state":null,"city":null,"zip":null,"lead_created_at":null,"free_trial_started_at":null,"address":{"country":null,"state":null,"city":null,"address_zip":null},"mrr":0,"arr":0,"billing-system-url":null,"chartmogul-url":"https://app.chartmogul.com/#/customers/217637584-Test_Tasks","billing-system-type":"Import
+      API","currency":"KRW","currency-sign":"₩","owner":null,"website_url":null}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "792"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Apr 2025 05:44:29 GMT
+      Retry-Count:
+      - "0"
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"assignee":"keith+test1@chartmogul.com","completed_at":"2025-04-20T00:00:00Z","customer_uuid":"cus_0668b1c2-2006-11f0-ad7c-536cb08c2a76","due_date":"2025-04-30T00:00:00Z","task_details":"This
+      is some task details text."}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - chartmogul-go/v4
+    url: https://api.chartmogul.com/v1/tasks
+    method: POST
+  response:
+    body: '{"task_uuid":"06a25846-2006-11f0-ad7d-73c588cd4a17","customer_uuid":"cus_0668b1c2-2006-11f0-ad7c-536cb08c2a76","task_details":"This
+      is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":"2025-04-20T00:00:00.000Z","created_at":"2025-04-23T05:44:30.166Z","updated_at":"2025-04-23T05:44:30.166Z"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "360"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Apr 2025 05:44:30 GMT
+      Retry-Count:
+      - "0"
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - chartmogul-go/v4
+    url: https://api.chartmogul.com/v1/tasks?customer_uuid=cus_0668b1c2-2006-11f0-ad7c-536cb08c2a76&per_page=10
+    method: GET
+  response:
+    body: '{"entries":[{"task_uuid":"06a25846-2006-11f0-ad7d-73c588cd4a17","customer_uuid":"cus_0668b1c2-2006-11f0-ad7c-536cb08c2a76","task_details":"This
+      is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":"2025-04-20T00:00:00.000Z","created_at":"2025-04-23T05:44:30.166Z","updated_at":"2025-04-23T05:44:30.166Z"}],"cursor":"MjAyNS0wNC0yM1QwNTo0NDozMC4xNjY3MzYwMDBaJjA2YTI1ODQ2LTIwMDYtMTFmMC1hZDdkLTczYzU4OGNkNGExNw==","has_more":false}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "495"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Apr 2025 05:44:30 GMT
+      Retry-Count:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - chartmogul-go/v4
+    url: https://api.chartmogul.com/v1/tasks/06a25846-2006-11f0-ad7d-73c588cd4a17
+    method: GET
+  response:
+    body: '{"task_uuid":"06a25846-2006-11f0-ad7d-73c588cd4a17","customer_uuid":"cus_0668b1c2-2006-11f0-ad7c-536cb08c2a76","task_details":"This
+      is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":"2025-04-20T00:00:00.000Z","created_at":"2025-04-23T05:44:30.166Z","updated_at":"2025-04-23T05:44:30.166Z"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "360"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Apr 2025 05:44:30 GMT
+      Retry-Count:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"task_details":"This is some other task details text."}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - chartmogul-go/v4
+    url: https://api.chartmogul.com/v1/tasks/06a25846-2006-11f0-ad7d-73c588cd4a17
+    method: PATCH
+  response:
+    body: '{"task_uuid":"06a25846-2006-11f0-ad7d-73c588cd4a17","customer_uuid":"cus_0668b1c2-2006-11f0-ad7c-536cb08c2a76","task_details":"This
+      is some other task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":"2025-04-20T00:00:00.000Z","created_at":"2025-04-23T05:44:30.166Z","updated_at":"2025-04-23T05:44:31.116Z"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "366"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Apr 2025 05:44:31 GMT
+      Retry-Count:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - chartmogul-go/v4
+    url: https://api.chartmogul.com/v1/tasks/06a25846-2006-11f0-ad7d-73c588cd4a17
+    method: GET
+  response:
+    body: '{"task_uuid":"06a25846-2006-11f0-ad7d-73c588cd4a17","customer_uuid":"cus_0668b1c2-2006-11f0-ad7c-536cb08c2a76","task_details":"This
+      is some other task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":"2025-04-20T00:00:00.000Z","created_at":"2025-04-23T05:44:30.166Z","updated_at":"2025-04-23T05:44:31.116Z"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "366"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Apr 2025 05:44:31 GMT
+      Retry-Count:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"assignee":"keith+test1@chartmogul.com","completed_at":"2025-05-20T00:00:00Z","customer_uuid":"cus_0668b1c2-2006-11f0-ad7c-536cb08c2a76","due_date":"2025-05-30T00:00:00Z","task_details":"This
+      is details text for another task."}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - chartmogul-go/v4
+    url: https://api.chartmogul.com/v1/tasks
+    method: POST
+  response:
+    body: '{"task_uuid":"079a1234-2006-11f0-bf97-bb34246a0d09","customer_uuid":"cus_0668b1c2-2006-11f0-ad7c-536cb08c2a76","task_details":"This
+      is details text for another task.","assignee":"keith+test1@chartmogul.com","due_date":"2025-05-30T00:00:00.000Z","completed_at":"2025-05-20T00:00:00.000Z","created_at":"2025-04-23T05:44:31.789Z","updated_at":"2025-04-23T05:44:31.789Z"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "367"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Apr 2025 05:44:31 GMT
+      Retry-Count:
+      - "0"
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - chartmogul-go/v4
+    url: https://api.chartmogul.com/v1/tasks/079a1234-2006-11f0-bf97-bb34246a0d09
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 23 Apr 2025 05:44:32 GMT
+      Retry-Count:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - chartmogul-go/v4
+    url: https://api.chartmogul.com/v1/data_sources/ds_0629fa9a-2006-11f0-ad7b-cfb392f9e98a
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 23 Apr 2025 05:44:32 GMT
+      Retry-Count:
+      - "0"
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/integration_tests/tasks_test.go
+++ b/integration_tests/tasks_test.go
@@ -1,0 +1,120 @@
+package integration
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"reflect"
+	"testing"
+
+	cm "github.com/chartmogul/chartmogul-go/v4"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/parnurzeal/gorequest"
+)
+
+func TestTasksIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Integration test.")
+	}
+
+	r, err := NewRecorderWithAuthFilter("./fixtures/tasks")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer r.Stop() //nolint
+
+	api := &cm.API{
+		ApiKey: os.Getenv("CHARTMOGUL_API_KEY"),
+		Client: &http.Client{Transport: r},
+	}
+
+	gorequest.DisableTransportSwap = true
+
+	ds, err := api.CreateDataSource("Test Tasks")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer api.DeleteDataSource(ds.UUID) //nolint
+
+	cus1, err := api.CreateCustomer(&cm.NewCustomer{
+		Name:           "Test Tasks",
+		ExternalID:     "ext_customer_1",
+		DataSourceUUID: ds.UUID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newTaskParams := &cm.NewTask{
+		CustomerUUID: cus1.UUID,
+		Assignee:     "keith+test1@chartmogul.com",
+		TaskDetails:  "This is some task details text.",
+		DueDate:      "2025-04-30T00:00:00Z",
+		CompletedAt:  "2025-04-20T00:00:00Z",
+	}
+	newTask, err := api.CreateTask(newTaskParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	allTasks, err := api.ListTasks(&cm.ListTasksParams{
+		CustomerUUID: cus1.UUID,
+		Cursor:       cm.Cursor{PerPage: 10},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var expectedAllTasks *cm.Tasks = &cm.Tasks{
+		Entries: []*cm.Task{newTask},
+	}
+	expectedAllTasks.Cursor = allTasks.Cursor
+	expectedAllTasks.HasMore = false
+
+	if !reflect.DeepEqual(allTasks, expectedAllTasks) {
+		spew.Dump(allTasks)
+		spew.Dump(expectedAllTasks)
+		t.Fatal("All tasks are not equal!")
+	}
+
+	retrievedTask, err := api.RetrieveTask(newTask.UUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(retrievedTask, newTask) {
+		spew.Dump(retrievedTask)
+		t.Fatal("Created task is not equal!")
+	}
+
+	updatedTaskParams := &cm.UpdateTask{
+		TaskDetails: "This is some other task details text.",
+	}
+	updatedTask, err := api.UpdateTask(updatedTaskParams, retrievedTask.UUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedRetrievedTask, err := api.RetrieveTask(updatedTask.UUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(updatedTask, updatedRetrievedTask) {
+		spew.Dump(updatedRetrievedTask)
+		t.Fatal("Updated task is not equal!")
+	}
+
+	otherTaskParams := &cm.NewTask{
+		CustomerUUID: cus1.UUID,
+		Assignee:     "keith+test1@chartmogul.com",
+		TaskDetails:  "This is details text for another task.",
+		DueDate:      "2025-05-30T00:00:00Z",
+		CompletedAt:  "2025-05-20T00:00:00Z",
+	}
+	otherTask, err := api.CreateTask(otherTaskParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deleteErr := api.DeleteTask(otherTask.UUID)
+	if deleteErr != nil {
+		t.Fatal(err)
+	}
+}

--- a/tasks.go
+++ b/tasks.go
@@ -5,32 +5,32 @@ type Task struct {
 	UUID string `json:"task_uuid"`
 	// Basic info
 	CustomerUUID string `json:"customer_uuid"`
-	Assignee		 string `json:"assignee"`
-	TaskDetails	 string `json:"task_details"`
-	DueDate			 string `json:"due_date"`
-	CompletedAt	 string `json:"completed_at,omitempty"`
+	Assignee     string `json:"assignee"`
+	TaskDetails  string `json:"task_details"`
+	DueDate      string `json:"due_date"`
+	CompletedAt  string `json:"completed_at,omitempty"`
 	CreatedAt    string `json:"created_at"`
 	UpdatedAt    string `json:"updated_at"`
 }
 
 // UpdateTask allows for updating a task through the update endpoint.
 type UpdateTask struct {
-	Assignee		string `json:"assignee,omitempty"`
-	TaskDetails	string `json:"task_details,omitempty"`
-	DueDate			string `json:"due_date,omitempty"`
-	CompletedAt	string `json:"completed_at,omitempty"`
+	Assignee    string `json:"assignee,omitempty"`
+	TaskDetails string `json:"task_details,omitempty"`
+	DueDate     string `json:"due_date,omitempty"`
+	CompletedAt string `json:"completed_at,omitempty"`
 }
 
 // NewTask allows for creating a task through the new endpoint.
 type NewTask struct {
 	// Obligatory
 	CustomerUUID string `json:"customer_uuid"`
-	Assignee		 string `json:"assignee"`
-	TaskDetails	 string `json:"task_details"`
-	DueDate			 string `json:"due_date"`
+	Assignee     string `json:"assignee"`
+	TaskDetails  string `json:"task_details"`
+	DueDate      string `json:"due_date"`
 
 	// Optional
-	CompletedAt	 string `json:"completed_at,omitempty"`
+	CompletedAt  string `json:"completed_at,omitempty"`
 }
 
 // ListTasksParams = parameters for listing tasks in API.

--- a/tasks.go
+++ b/tasks.go
@@ -1,0 +1,94 @@
+package chartmogul
+
+// Task is the task as represented in the API.
+type Task struct {
+	UUID string `json:"task_uuid"`
+	// Basic info
+	CustomerUUID string `json:"customer_uuid"`
+	Assignee		 string `json:"assignee"`
+	TaskDetails	 string `json:"task_details"`
+	DueDate			 string `json:"due_date"`
+	CompletedAt	 string `json:"completed_at,omitempty"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+}
+
+// UpdateTask allows for updating a task through the update endpoint.
+type UpdateTask struct {
+	Assignee		string `json:"assignee,omitempty"`
+	TaskDetails	string `json:"task_details,omitempty"`
+	DueDate			string `json:"due_date,omitempty"`
+	CompletedAt	string `json:"completed_at,omitempty"`
+}
+
+// NewTask allows for creating a task through the new endpoint.
+type NewTask struct {
+	// Obligatory
+	CustomerUUID string `json:"customer_uuid"`
+	Assignee		 string `json:"assignee"`
+	TaskDetails	 string `json:"task_details"`
+	DueDate			 string `json:"due_date"`
+
+	// Optional
+	CompletedAt	 string `json:"completed_at,omitempty"`
+}
+
+// ListTasksParams = parameters for listing tasks in API.
+type ListTasksParams struct {
+	CustomerUUID string `json:"customer_uuid"`
+	Cursor
+}
+
+// Tasks is result of listing tasks in API.
+type Tasks struct {
+	Entries []*Task `json:"entries"`
+	Pagination
+}
+
+const (
+	singleTaskEndpoint = "tasks/:uuid"
+	tasksEndpoint = "tasks"
+)
+
+// CreateTask creates the task through the API.
+//
+// See https://dev.chartmogul.com/reference/create-a-task
+func (api API) CreateTask(input *NewTask) (*Task, error) {
+	result := &Task{}
+	return result, api.create(tasksEndpoint, input, result)
+}
+
+// RetrieveTask returns one task from the API.
+//
+// See https://dev.chartmogul.com/reference/retrieve-a-task
+func (api API) RetrieveTask(taskUUID string) (*Task, error) {
+	result := &Task{}
+	return result, api.retrieve(singleTaskEndpoint, taskUUID, result)
+}
+
+// UpdateTask updates one task through the API.
+//
+// See https://dev.chartmogul.com/reference/update-a-task
+func (api API) UpdateTask(input *UpdateTask, taskUUID string) (*Task, error) {
+	output := &Task{}
+	return output, api.update(singleTaskEndpoint, taskUUID, input, output)
+}
+
+// ListTasks lists all tasks.
+//
+// See https://dev.chartmogul.com/reference/list-tasks
+func (api API) ListTasks(listTasksParams *ListTasksParams) (*Tasks, error) {
+	result := &Tasks{}
+	query := make([]interface{}, 0, 1)
+	if listTasksParams != nil {
+					query = append(query, *listTasksParams)
+	}
+	return result, api.list(tasksEndpoint, result, query...)
+}
+
+// DeleteTask deletes one task by UUID.
+//
+// See https://dev.chartmogul.com/reference/delete-a-task
+func (api API) DeleteTask(taskUUID string) error {
+	return api.delete(singleTaskEndpoint, taskUUID)
+}

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -1,0 +1,215 @@
+package chartmogul
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestListTasks(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/tasks?customer_uuid=cus_00000000-0000-0000-0000-000000000000&per_page=1" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				//nolint
+				w.Write([]byte(`{
+					"entries": [{
+						"task_uuid": "00000000-0000-0000-0000-000000000000",
+						"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+						"assignee": "Customer (customer@example.com)",
+						"task_details": "This is some task details text.",
+						"due_date": "2025-04-30T00:00:00Z",
+						"completed_at": "2025-04-20T00:00:00Z",
+						"created_at": "2025-04-01T12:00:00.000Z",
+						"updated_at": "2025-04-01T12:00:00.000Z"
+					}],
+					"has_more": false,
+					"cursor": "88abf99"
+				}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+	}
+	params := &ListTasksParams{Cursor: Cursor{PerPage: 1}, CustomerUUID: "cus_00000000-0000-0000-0000-000000000000"}
+	tasks, err := tested.ListTasks(params)
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if len(tasks.Entries) == 0 {
+		spew.Dump(tasks)
+		t.Fatal("Unexpected result")
+	}
+}
+
+func TestRetrieveTask(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/tasks/00000000-0000-0000-0000-000000000000" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				//nolint
+				w.Write([]byte(`{
+					"task_uuid": "00000000-0000-0000-0000-000000000000",
+					"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+					"assignee": "Customer (customer@example.com)",
+					"task_details": "This is some task details text.",
+					"due_date": "2025-04-30T00:00:00Z",
+					"completed_at": "2025-04-20T00:00:00Z",
+					"created_at": "2025-04-01T12:00:00.000Z",
+					"updated_at": "2025-04-01T12:00:00.000Z"
+				}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+	}
+	task, err := tested.RetrieveTask("00000000-0000-0000-0000-000000000000")
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if task == nil {
+		spew.Dump(task)
+		t.Fatal("Unexpected result")
+	}
+}
+
+func TestCreateTask(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "POST" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/tasks" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusCreated)
+				//nolint
+				w.Write([]byte(`{
+					"task_uuid": "00000000-0000-0000-0000-000000000000",
+					"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+					"assignee": "Customer (customer@example.com)",
+					"task_details": "This is some task details text.",
+					"due_date": "2025-04-30T00:00:00Z",
+					"completed_at": "2025-04-20T00:00:00Z",
+					"created_at": "2025-04-01T12:00:00.000Z",
+					"updated_at": "2025-04-01T12:00:00.000Z"
+				}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+	}
+
+	task, err := tested.CreateTask(&NewTask{
+		CustomerUUID: "cus_00000000-0000-0000-0000-000000000000",
+		Assignee:     "customer@example.com",
+		TaskDetails:  "This is some task details text.",
+		DueDate:      "2025-04-30T00:00:00Z",
+		CompletedAt:  "2025-04-20T00:00:00Z",
+	})
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if task.UUID != "00000000-0000-0000-0000-000000000000" {
+		spew.Dump(task)
+		t.Fatal("Unexpected result")
+	}
+}
+
+func TestUpdateTask(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "PATCH" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/tasks/00000000-0000-0000-0000-000000000000" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				//nolint
+				w.Write([]byte(`{
+					"task_uuid": "00000000-0000-0000-0000-000000000000",
+					"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+					"assignee": "Customer (customer@example.com)",
+					"task_details": "This is some other task details text.",
+					"due_date": "2025-04-30T00:00:00Z",
+					"completed_at": "2025-04-20T00:00:00Z",
+					"created_at": "2025-04-01T12:00:00.000Z",
+					"updated_at": "2025-04-01T12:00:00.000Z"
+				}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+	}
+
+	task, err := tested.UpdateTask(&UpdateTask{
+		TaskDetails: "This is some other task details text.",
+	}, "00000000-0000-0000-0000-000000000000")
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if task.TaskDetails != "This is some other task details text." {
+		spew.Dump(task)
+		t.Fatal("Unexpected result")
+	}
+}
+
+func TestDeleteTask(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "DELETE" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/tasks/00000000-0000-0000-0000-000000000000" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+	}
+
+	err := tested.DeleteTask("00000000-0000-0000-0000-000000000000")
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+}

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -24,7 +24,7 @@ func TestListTasks(t *testing.T) {
 					"entries": [{
 						"task_uuid": "00000000-0000-0000-0000-000000000000",
 						"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
-						"assignee": "Customer (customer@example.com)",
+						"assignee": "keith+test1@chartmogul.com",
 						"task_details": "This is some task details text.",
 						"due_date": "2025-04-30T00:00:00Z",
 						"completed_at": "2025-04-20T00:00:00Z",
@@ -69,7 +69,7 @@ func TestRetrieveTask(t *testing.T) {
 				w.Write([]byte(`{
 					"task_uuid": "00000000-0000-0000-0000-000000000000",
 					"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
-					"assignee": "Customer (customer@example.com)",
+					"assignee": "keith+test1@chartmogul.com",
 					"task_details": "This is some task details text.",
 					"due_date": "2025-04-30T00:00:00Z",
 					"completed_at": "2025-04-20T00:00:00Z",
@@ -110,7 +110,7 @@ func TestCreateTask(t *testing.T) {
 				w.Write([]byte(`{
 					"task_uuid": "00000000-0000-0000-0000-000000000000",
 					"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
-					"assignee": "Customer (customer@example.com)",
+					"assignee": "keith+test1@chartmogul.com",
 					"task_details": "This is some task details text.",
 					"due_date": "2025-04-30T00:00:00Z",
 					"completed_at": "2025-04-20T00:00:00Z",
@@ -127,7 +127,7 @@ func TestCreateTask(t *testing.T) {
 
 	task, err := tested.CreateTask(&NewTask{
 		CustomerUUID: "cus_00000000-0000-0000-0000-000000000000",
-		Assignee:     "customer@example.com",
+		Assignee:     "keith+test1@chartmogul.com",
 		TaskDetails:  "This is some task details text.",
 		DueDate:      "2025-04-30T00:00:00Z",
 		CompletedAt:  "2025-04-20T00:00:00Z",
@@ -158,7 +158,7 @@ func TestUpdateTask(t *testing.T) {
 				w.Write([]byte(`{
 					"task_uuid": "00000000-0000-0000-0000-000000000000",
 					"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
-					"assignee": "Customer (customer@example.com)",
+					"assignee": "keith+test1@chartmogul.com",
 					"task_details": "This is some other task details text.",
 					"due_date": "2025-04-30T00:00:00Z",
 					"completed_at": "2025-04-20T00:00:00Z",


### PR DESCRIPTION
This PR adds support for the Tasks API to the SDK.

The spec for this project can be found [here](https://www.notion.so/chartmogul/API-for-Tasks-c87a8c8de97d495a92bf7266c49ff6ec).

### Customer Additions

```go
api.ListCustomerTasks(&cm.ListTasksParams{}, "customerUUID")
api.CreateCustomerTask(&cm.NewTask{}, "customerUUID")
```

### Task Additions

```go
api.CreateTask(&cm.NewTask{})
api.RetrieveTask("taskUUID")
api.ListTask(&cm.ListTaskParams{})
api.UpdateTask(&cm.UpdateTask{}, "taskUUID")
api.DeleteTask("taskUUID")
```