### PR TITLE
Make customer_uuid optional in the List customer notes endpoint [DEL-284]

### DIFF
--- a/customer_notes_test.go
+++ b/customer_notes_test.go
@@ -15,7 +15,7 @@ func TestListNotes(t *testing.T) {
 				if r.Method != "GET" {
 					t.Errorf("Unexpected method %v", r.Method)
 				}
-				if r.RequestURI != "/v/customer_notes?customer_uuid=cus_00000000-0000-0000-0000-000000000000&per_page=1" {
+				if r.RequestURI != "/v/customer_notes?per_page=1" {
 					t.Errorf("Unexpected URI %v", r.RequestURI)
 				}
 				w.WriteHeader(http.StatusOK)
@@ -41,7 +41,7 @@ func TestListNotes(t *testing.T) {
 	tested := &API{
 		ApiKey: "token",
 	}
-	params := &ListNotesParams{Cursor: Cursor{PerPage: 1}, CustomerUUID: "cus_00000000-0000-0000-0000-000000000000"}
+	params := &ListNotesParams{Cursor: Cursor{PerPage: 1}}
 	customer_notes, err := tested.ListNotes(params)
 
 	if err != nil {

--- a/customer_notes_test.go
+++ b/customer_notes_test.go
@@ -54,6 +54,52 @@ func TestListNotes(t *testing.T) {
 	}
 }
 
+func TestListNotesWithCustomerUuid(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/customer_notes?customer_uuid=cus_00000000-0000-0000-0000-000000000000&per_page=1" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				//nolint
+				w.Write([]byte(`{
+					"entries": [{
+						"uuid": "note_00000000-0000-0000-0000-000000000000",
+						"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+						"type": "note",
+						"author": "John Doe (john@example.com)",
+						"text": "This is a note",
+						"call_duration": 0,
+						"created_at": "2015-06-09T19:20:30Z",
+						"updated_at": "2015-06-09T19:20:30Z"
+					}],
+					"has_more": false,
+					"cursor": "88abf99"
+				}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+	}
+	params := &ListNotesParams{Cursor: Cursor{PerPage: 1}, CustomerUUID: "cus_00000000-0000-0000-0000-000000000000"}
+	customer_notes, err := tested.ListNotes(params)
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if len(customer_notes.Entries) == 0 {
+		spew.Dump(customer_notes)
+		t.Fatal("Unexpected result")
+	}
+}
+
 func TestRetrieveNote(t *testing.T) {
 	server := httptest.NewServer(
 		http.HandlerFunc(

--- a/notes.go
+++ b/notes.go
@@ -38,7 +38,7 @@ type NewNote struct {
 
 // ListNoteParams = parameters for listing customer notes in API.
 type ListNotesParams struct {
-	CustomerUUID string `json:"customer_uuid"`
+	CustomerUUID string `json:"customer_uuid,omitempty"`
 	Cursor
 }
 

--- a/opportunities.go
+++ b/opportunities.go
@@ -50,7 +50,7 @@ type NewOpportunity struct {
 
 // ListOpportunitiesParams = parameters for listing customer opportunities in API.
 type ListOpportunitiesParams struct {
-	CustomerUUID string `json:"customer_uuid"`
+	CustomerUUID string `json:"customer_uuid,omitempty"`
 	Cursor
 }
 

--- a/opportunities_test.go
+++ b/opportunities_test.go
@@ -60,6 +60,58 @@ func TestListOpportunities(t *testing.T) {
 	}
 }
 
+func TestListOpportunitiesWithCustomerUuid(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/opportunities?customer_uuid=cus_00000000-0000-0000-0000-000000000000&per_page=1" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				//nolint
+				w.Write([]byte(`{
+					"entries": [{
+						"uuid": "00000000-0000-0000-0000-000000000000",
+						"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+						"owner": "test1@example.org",
+						"pipeline": "New business 1",
+						"pipeline_stage": "Discovery",
+						"estimated_close_date": "2023-12-22",
+						"currency": "USD",
+						"amount_in_cents": 100,
+						"type": "recurring",
+						"forecast_category": "pipeline",
+						"win_likelihood": 3,
+						"custom": {"from_campaign": true},
+						"created_at": "2024-03-13T07:33:28.356Z",
+						"updated_at": "2024-03-13T07:33:28.356Z"
+					}],
+					"has_more": false,
+					"cursor": "88abf99"
+				}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+	}
+	params := &ListOpportunitiesParams{Cursor: Cursor{PerPage: 1}, CustomerUUID: "cus_00000000-0000-0000-0000-000000000000"}
+	opportunities, err := tested.ListOpportunities(params)
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if len(opportunities.Entries) == 0 {
+		spew.Dump(opportunities)
+		t.Fatal("Unexpected result")
+	}
+}
+
 func TestRetrieveOpportunity(t *testing.T) {
 	server := httptest.NewServer(
 		http.HandlerFunc(

--- a/opportunities_test.go
+++ b/opportunities_test.go
@@ -15,7 +15,7 @@ func TestListOpportunities(t *testing.T) {
 				if r.Method != "GET" {
 					t.Errorf("Unexpected method %v", r.Method)
 				}
-				if r.RequestURI != "/v/opportunities?customer_uuid=cus_00000000-0000-0000-0000-000000000000&per_page=1" {
+				if r.RequestURI != "/v/opportunities?per_page=1" {
 					t.Errorf("Unexpected URI %v", r.RequestURI)
 				}
 				w.WriteHeader(http.StatusOK)
@@ -47,7 +47,7 @@ func TestListOpportunities(t *testing.T) {
 	tested := &API{
 		ApiKey: "token",
 	}
-	params := &ListOpportunitiesParams{Cursor: Cursor{PerPage: 1}, CustomerUUID: "cus_00000000-0000-0000-0000-000000000000"}
+	params := &ListOpportunitiesParams{Cursor: Cursor{PerPage: 1}}
 	opportunities, err := tested.ListOpportunities(params)
 
 	if err != nil {

--- a/tasks.go
+++ b/tasks.go
@@ -35,7 +35,7 @@ type NewTask struct {
 
 // ListTasksParams = parameters for listing tasks in API.
 type ListTasksParams struct {
-	CustomerUUID string `json:"customer_uuid"`
+	CustomerUUID string `json:"customer_uuid,omitempty"`
 	Cursor
 }
 

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -54,6 +54,52 @@ func TestListTasks(t *testing.T) {
 	}
 }
 
+func TestListTasksWithCustomerUuid(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/tasks?customer_uuid=cus_00000000-0000-0000-0000-000000000000&per_page=1" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+				//nolint
+				w.Write([]byte(`{
+					"entries": [{
+						"task_uuid": "00000000-0000-0000-0000-000000000000",
+						"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+						"assignee": "keith+test1@chartmogul.com",
+						"task_details": "This is some task details text.",
+						"due_date": "2025-04-30T00:00:00Z",
+						"completed_at": "2025-04-20T00:00:00Z",
+						"created_at": "2025-04-01T12:00:00.000Z",
+						"updated_at": "2025-04-01T12:00:00.000Z"
+					}],
+					"has_more": false,
+					"cursor": "88abf99"
+				}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+	}
+	params := &ListTasksParams{Cursor: Cursor{PerPage: 1}, CustomerUUID: "cus_00000000-0000-0000-0000-000000000000"}
+	tasks, err := tested.ListTasks(params)
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if len(tasks.Entries) == 0 {
+		spew.Dump(tasks)
+		t.Fatal("Unexpected result")
+	}
+}
+
 func TestRetrieveTask(t *testing.T) {
 	server := httptest.NewServer(
 		http.HandlerFunc(

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -15,7 +15,7 @@ func TestListTasks(t *testing.T) {
 				if r.Method != "GET" {
 					t.Errorf("Unexpected method %v", r.Method)
 				}
-				if r.RequestURI != "/v/tasks?customer_uuid=cus_00000000-0000-0000-0000-000000000000&per_page=1" {
+				if r.RequestURI != "/v/tasks?per_page=1" {
 					t.Errorf("Unexpected URI %v", r.RequestURI)
 				}
 				w.WriteHeader(http.StatusOK)
@@ -41,7 +41,7 @@ func TestListTasks(t *testing.T) {
 	tested := &API{
 		ApiKey: "token",
 	}
-	params := &ListTasksParams{Cursor: Cursor{PerPage: 1}, CustomerUUID: "cus_00000000-0000-0000-0000-000000000000"}
+	params := &ListTasksParams{Cursor: Cursor{PerPage: 1}}
 	tasks, err := tested.ListTasks(params)
 
 	if err != nil {


### PR DESCRIPTION
### Context

Currently, the [GET `/v1/customer_notes` endpoint](https://dev.chartmogul.com/reference/notes-and-call-logs/list/) requires clients to provide `customer_uuid`. When our clients want to sync Chartmogul data into their systems, this constraint forces them to create a large number of requests (one for each customer) - creating unnecessary load on our servers. In https://github.com/chartmogul/platform/pull/25985 we're making the `customer_uuid` param optional.

### Changes

- Make `customer_uuid` optional in `ListNotesParams`
- :camping: Make `customer_uuid` optional in `ListOpportunitiesParams` and `ListTasksParams`