### PR TITLE
Add fetching additional DataSource fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,30 @@ Available methods in Import API:
 
 ```go
 api.CreateDataSource("name")
-api.ListDataSources()
-api.RetrieveDataSource("uuid")
 api.DeleteDataSource("uuid")
+api.ListDataSources()
+// List with extra data parameters
+listExtraParams := &cm.ExtraDataSourceParams{
+    WithProcessingStatus: &trueBool,
+    WithAutoChurnSubscriptionSetting: &trueBool,
+    WithInvoiceHandlingSetting: &trueBool,
+}
+api.ListDataSources(listExtraParams)
+// List with filtering and extra data parameters
+listParams := &cm.ListDataSourcesParams{
+    Name: "stripe",
+    System: "stripe",
+    WithProcessingStatus: &trueBool,
+    WithInvoiceHandlingSetting: &trueBool,
+}
+api.ListDataSourcesWithFilters(listParams)
+api.RetrieveDataSource("uuid")
+retrieveExtraParams := &cm.ExtraDataSourceParams{
+    WithProcessingStatus: &trueBool,
+    WithAutoChurnSubscriptionSetting: &trueBool,
+    WithInvoiceHandlingSetting: &trueBool,
+}
+api.RetrieveDataSource("uuid", retrieveExtraParams)
 ```
 
 #### [Customers](https://dev.chartmogul.com/reference/customers/)

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -52,8 +52,8 @@ type IApi interface {
 	// Data sources
 	CreateDataSource(name string) (*DataSource, error)
 	CreateDataSourceWithSystem(dataSource *DataSource) (*DataSource, error)
-	RetrieveDataSource(dataSourceUUID string) (*DataSource, error)
-	ListDataSources() (*DataSources, error)
+	RetrieveDataSource(dataSourceUUID string, params ...*ExtraDataSourceParams) (*DataSource, error)
+	ListDataSources(params ...*ExtraDataSourceParams) (*DataSources, error)
 	ListDataSourcesWithFilters(listDataSourcesParams *ListDataSourcesParams) (*DataSources, error)
 	PurgeDataSource(dataSourceUUID string) error
 	EmptyDataSource(dataSourceUUID string) error

--- a/datasources.go
+++ b/datasources.go
@@ -50,11 +50,9 @@ type ExtraDataSourceParams struct {
 
 // ListDataSourcesParams are optional parameters for listing data sources.
 type ListDataSourcesParams struct {
-	Name                             string `json:"name,omitempty"`
-	System                           string `json:"system,omitempty"`
-	WithProcessingStatus             *bool  `json:"with_processing_status,omitempty"`
-	WithAutoChurnSubscriptionSetting *bool  `json:"with_auto_churn_subscription_setting,omitempty"`
-	WithInvoiceHandlingSetting       *bool  `json:"with_invoice_handling_setting,omitempty"`
+	ExtraDataSourceParams
+	Name                  string `json:"name,omitempty"`
+	System                string `json:"system,omitempty"`
 }
 
 // createDataSourceCall represents arguments to be marshalled into JSON.

--- a/datasources.go
+++ b/datasources.go
@@ -7,21 +7,6 @@ type ProcessingStatus struct {
 	Failed    *int `json:"failed,omitempty"`
 }
 
-// InvoiceHandlingSetting represents the invoice handling settings for a data source.
-type InvoiceHandlingSetting struct {
-	Manual    *InvoiceHandlingMode `json:"manual,omitempty"`
-	Automatic *InvoiceHandlingMode `json:"automatic,omitempty"`
-}
-
-// InvoiceHandlingMode represents the configuration for invoice handling mode.
-type InvoiceHandlingMode struct {
-	CreateSubscriptionWhenInvoiceIs         string `json:"create_subscription_when_invoice_is"`
-	UpdateSubscriptionWhenInvoiceIs         string `json:"update_subscription_when_invoice_is"`
-	PreventSubscriptionForInvoiceVoided     bool   `json:"prevent_subscription_for_invoice_voided"`
-	PreventSubscriptionForInvoiceRefunded   bool   `json:"prevent_subscription_for_invoice_refunded"`
-	PreventSubscriptionForInvoiceWrittenOff bool   `json:"prevent_subscription_for_invoice_written_off"`
-}
-
 // AutoChurnSubscriptionSetting represents the auto churn subscription setting for a data source.
 type AutoChurnSubscriptionSetting struct {
 	Enabled  bool `json:"enabled"`
@@ -38,7 +23,7 @@ type DataSource struct {
 	System                       string                        `json:"system"`
 	ProcessingStatus             *ProcessingStatus             `json:"processing_status,omitempty"`
 	AutoChurnSubscriptionSetting *AutoChurnSubscriptionSetting `json:"auto_churn_subscription_setting,omitempty"`
-	InvoiceHandlingSetting       *InvoiceHandlingSetting       `json:"invoice_handling_setting,omitempty"`
+	InvoiceHandlingSetting       map[string]interface{}        `json:"invoice_handling_setting,omitempty"`
 	Errors                       Errors                        `json:"errors,omitempty"`
 }
 

--- a/datasources.go
+++ b/datasources.go
@@ -22,18 +22,24 @@ type InvoiceHandlingMode struct {
 	PreventSubscriptionForInvoiceWrittenOff bool   `json:"prevent_subscription_for_invoice_written_off"`
 }
 
+// AutoChurnSubscriptionSetting represents the auto churn subscription setting for a data source.
+type AutoChurnSubscriptionSetting struct {
+	Enabled  bool `json:"enabled"`
+	Interval *int `json:"interval"`
+}
+
 // DataSource represents API data source in ChartMogul.
 // See https://dev.chartmogul.com/v1.0/reference#list-data-sources
 type DataSource struct {
-	UUID                         string                  `json:"uuid"`
-	Name                         string                  `json:"name"`
-	CreatedAt                    string                  `json:"created_at"`
-	Status                       string                  `json:"status"`
-	System                       string                  `json:"system"`
-	ProcessingStatus             *ProcessingStatus       `json:"processing_status,omitempty"`
-	AutoChurnSubscriptionSetting *bool                   `json:"auto_churn_subscription_setting,omitempty"`
-	InvoiceHandlingSetting       *InvoiceHandlingSetting `json:"invoice_handling_setting,omitempty"`
-	Errors                       Errors                  `json:"errors,omitempty"`
+	UUID                         string                        `json:"uuid"`
+	Name                         string                        `json:"name"`
+	CreatedAt                    string                        `json:"created_at"`
+	Status                       string                        `json:"status"`
+	System                       string                        `json:"system"`
+	ProcessingStatus             *ProcessingStatus             `json:"processing_status,omitempty"`
+	AutoChurnSubscriptionSetting *AutoChurnSubscriptionSetting `json:"auto_churn_subscription_setting,omitempty"`
+	InvoiceHandlingSetting       *InvoiceHandlingSetting       `json:"invoice_handling_setting,omitempty"`
+	Errors                       Errors                        `json:"errors,omitempty"`
 }
 
 // DataSources is the result of listing data sources, but doesn't contain any paging.
@@ -51,8 +57,8 @@ type ExtraDataSourceParams struct {
 // ListDataSourcesParams are optional parameters for listing data sources.
 type ListDataSourcesParams struct {
 	ExtraDataSourceParams
-	Name                  string `json:"name,omitempty"`
-	System                string `json:"system,omitempty"`
+	Name   string `json:"name,omitempty"`
+	System string `json:"system,omitempty"`
 }
 
 // createDataSourceCall represents arguments to be marshalled into JSON.

--- a/datasources.go
+++ b/datasources.go
@@ -1,14 +1,39 @@
 package chartmogul
 
+// ProcessingStatus represents the processing status of a data source.
+type ProcessingStatus struct {
+	Processed *int `json:"processed,omitempty"`
+	Pending   *int `json:"pending,omitempty"`
+	Failed    *int `json:"failed,omitempty"`
+}
+
+// InvoiceHandlingSetting represents the invoice handling settings for a data source.
+type InvoiceHandlingSetting struct {
+	Manual    *InvoiceHandlingMode `json:"manual,omitempty"`
+	Automatic *InvoiceHandlingMode `json:"automatic,omitempty"`
+}
+
+// InvoiceHandlingMode represents the configuration for invoice handling mode.
+type InvoiceHandlingMode struct {
+	CreateSubscriptionWhenInvoiceIs         string `json:"create_subscription_when_invoice_is"`
+	UpdateSubscriptionWhenInvoiceIs         string `json:"update_subscription_when_invoice_is"`
+	PreventSubscriptionForInvoiceVoided     bool   `json:"prevent_subscription_for_invoice_voided"`
+	PreventSubscriptionForInvoiceRefunded   bool   `json:"prevent_subscription_for_invoice_refunded"`
+	PreventSubscriptionForInvoiceWrittenOff bool   `json:"prevent_subscription_for_invoice_written_off"`
+}
+
 // DataSource represents API data source in ChartMogul.
 // See https://dev.chartmogul.com/v1.0/reference#list-data-sources
 type DataSource struct {
-	UUID      string `json:"uuid"`
-	Name      string `json:"name"`
-	CreatedAt string `json:"created_at"`
-	Status    string `json:"status"`
-	System    string `json:"system"`
-	Errors    Errors `json:"errors,omitempty"`
+	UUID                         string                  `json:"uuid"`
+	Name                         string                  `json:"name"`
+	CreatedAt                    string                  `json:"created_at"`
+	Status                       string                  `json:"status"`
+	System                       string                  `json:"system"`
+	ProcessingStatus             *ProcessingStatus       `json:"processing_status,omitempty"`
+	AutoChurnSubscriptionSetting *bool                   `json:"auto_churn_subscription_setting,omitempty"`
+	InvoiceHandlingSetting       *InvoiceHandlingSetting `json:"invoice_handling_setting,omitempty"`
+	Errors                       Errors                  `json:"errors,omitempty"`
 }
 
 // DataSources is the result of listing data sources, but doesn't contain any paging.
@@ -16,10 +41,20 @@ type DataSources struct {
 	DataSources []*DataSource `json:"data_sources"`
 }
 
+// ExtraDataSourceParams are optional parameters for additional data source information.
+type ExtraDataSourceParams struct {
+	WithProcessingStatus             *bool `json:"with_processing_status,omitempty"`
+	WithAutoChurnSubscriptionSetting *bool `json:"with_auto_churn_subscription_setting,omitempty"`
+	WithInvoiceHandlingSetting       *bool `json:"with_invoice_handling_setting,omitempty"`
+}
+
 // ListDataSourcesParams are optional parameters for listing data sources.
 type ListDataSourcesParams struct {
-	Name   string `json:"name,omitempty"`
-	System string `json:"system,omitempty"`
+	Name                             string `json:"name,omitempty"`
+	System                           string `json:"system,omitempty"`
+	WithProcessingStatus             *bool  `json:"with_processing_status,omitempty"`
+	WithAutoChurnSubscriptionSetting *bool  `json:"with_auto_churn_subscription_setting,omitempty"`
+	WithInvoiceHandlingSetting       *bool  `json:"with_invoice_handling_setting,omitempty"`
 }
 
 // createDataSourceCall represents arguments to be marshalled into JSON.
@@ -54,24 +89,47 @@ func (api API) CreateDataSourceWithSystem(dataSource *DataSource) (*DataSource, 
 }
 
 // RetrieveDataSource returns one Data Source by UUID.
+// Optionally accepts ExtraDataSourceParams for additional query options with named parameters:
+// - WithProcessingStatus: include processing status information
+// - WithAutoChurnSubscriptionSetting: include auto-churn subscription settings
+// - WithInvoiceHandlingSetting: include invoice handling settings
 //
 // See https://dev.chartmogul.com/v1.0/reference#data-sources
-func (api API) RetrieveDataSource(dataSourceUUID string) (*DataSource, error) {
+func (api API) RetrieveDataSource(dataSourceUUID string, params ...*ExtraDataSourceParams) (*DataSource, error) {
 	result := &DataSource{}
-	return result, api.retrieve(singleDataSourceEndpoint, dataSourceUUID, result)
+
+	if len(params) == 0 || params[0] == nil {
+		// No params provided - use original retrieve method
+		return result, api.retrieve(singleDataSourceEndpoint, dataSourceUUID, result)
+	}
+
+	return result, api.retrieveWithParams(singleDataSourceEndpoint, dataSourceUUID, result, params[0])
 }
 
 // ListDataSources lists all available Data Sources (no paging).
+// Optionally accepts ExtraDataSourceParams for additional query options with named parameters:
+// - WithProcessingStatus: include processing status information
+// - WithAutoChurnSubscriptionSetting: include auto-churn subscription settings
+// - WithInvoiceHandlingSetting: include invoice handling settings
 //
 // See https://dev.chartmogul.com/v1.0/reference#data-sources
-func (api API) ListDataSources() (*DataSources, error) {
+func (api API) ListDataSources(params ...*ExtraDataSourceParams) (*DataSources, error) {
 	ds := &DataSources{}
-	err := api.list(dataSourcesEndpoint, ds)
+	if len(params) == 0 || params[0] == nil {
+		// No params provided - use original list method
+		err := api.list(dataSourcesEndpoint, ds)
+		return ds, err
+	}
+
+	// Use list with query parameters
+	query := make([]interface{}, 0, 1)
+	query = append(query, *params[0])
+	err := api.list(dataSourcesEndpoint, ds, query...)
 	return ds, err
 }
 
 // ListDataSourcesWithFilters lists all available Data Sources (no paging).
-// * Allows filtering.
+// Accepts filtering parameters and extra data parameters in a single struct.
 //
 // See https://dev.chartmogul.com/v1.0/reference#data-sources
 func (api API) ListDataSourcesWithFilters(listDataSourcesParams *ListDataSourcesParams) (*DataSources, error) {

--- a/datasources_test.go
+++ b/datasources_test.go
@@ -48,3 +48,285 @@ func TestImportDataSources(t *testing.T) {
 	}
 	log.Println("Data source deleted.")
 }
+
+// TestListDataSourcesWithParams tests listing Data Sources with query parameters.
+func TestListDataSourcesWithParams(t *testing.T) {
+	if !*cm {
+		t.SkipNow()
+		return
+	}
+
+	ds, err := api.CreateDataSource(dsTestName)
+	if err != nil {
+		t.Error(err)
+	}
+	defer api.DeleteDataSource(ds.UUID)
+
+	trueBool := true
+	falseBool := false
+
+	// Test with all parameters
+	params := &ListDataSourcesParams{
+		Name:                             dsTestName,
+		WithProcessingStatus:             &trueBool,
+		WithAutoChurnSubscriptionSetting: &trueBool,
+		WithInvoiceHandlingSetting:       &trueBool,
+	}
+
+	res, err := api.ListDataSourcesWithFilters(params)
+	if err != nil {
+		t.Error(err)
+	}
+
+	found := false
+	for _, dataSource := range res.DataSources {
+		if dataSource.Name == dsTestName {
+			found = true
+			// When with_processing_status=true, ProcessingStatus should be included
+			if params.WithProcessingStatus != nil && *params.WithProcessingStatus {
+				if dataSource.ProcessingStatus == nil {
+					t.Errorf("Expected ProcessingStatus to be included when with_processing_status=true")
+				}
+			}
+			// When with_auto_churn_subscription_setting=true, AutoChurnSubscriptionSetting should be included
+			if params.WithAutoChurnSubscriptionSetting != nil && *params.WithAutoChurnSubscriptionSetting {
+				if dataSource.AutoChurnSubscriptionSetting == nil {
+					t.Errorf("Expected AutoChurnSubscriptionSetting to be included when with_auto_churn_subscription_setting=true")
+				}
+			}
+			// When with_invoice_handling_setting=true, InvoiceHandlingSetting should be included
+			if params.WithInvoiceHandlingSetting != nil && *params.WithInvoiceHandlingSetting {
+				if dataSource.InvoiceHandlingSetting == nil {
+					t.Errorf("Expected InvoiceHandlingSetting to be included when with_invoice_handling_setting=true")
+				}
+			}
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Data source not found in listing with filters! %+v", res)
+	}
+
+	// Test with parameters set to false
+	params.WithProcessingStatus = &falseBool
+	params.WithAutoChurnSubscriptionSetting = &falseBool
+	params.WithInvoiceHandlingSetting = &falseBool
+
+	res, err = api.ListDataSourcesWithFilters(params)
+	if err != nil {
+		t.Error(err)
+	}
+
+	found = false
+	for _, dataSource := range res.DataSources {
+		if dataSource.Name == dsTestName {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Data source not found in listing with false filters! %+v", res)
+	}
+
+	log.Println("Data sources listing with parameters tested successfully.")
+}
+
+// TestRetrieveDataSourceWithParams tests retrieving a Data Source with query parameters.
+func TestRetrieveDataSourceWithParams(t *testing.T) {
+	if !*cm {
+		t.SkipNow()
+		return
+	}
+
+	ds, err := api.CreateDataSource(dsTestName)
+	if err != nil {
+		t.Error(err)
+	}
+	defer api.DeleteDataSource(ds.UUID)
+
+	trueBool := true
+	falseBool := false
+
+	// Test with all parameters set to true
+	params := &ExtraDataSourceParams{
+		WithProcessingStatus:             &trueBool,
+		WithAutoChurnSubscriptionSetting: &trueBool,
+		WithInvoiceHandlingSetting:       &trueBool,
+	}
+
+	retrieved, err := api.RetrieveDataSource(ds.UUID, params)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if retrieved.UUID != ds.UUID {
+		t.Errorf("Data source UUIDs don't match - expected: %v, actual: %v", ds.UUID, retrieved.UUID)
+	}
+
+	// When with_processing_status=true, ProcessingStatus should be included
+	if retrieved.ProcessingStatus == nil {
+		t.Errorf("Expected ProcessingStatus to be included when with_processing_status=true")
+	}
+
+	// When with_auto_churn_subscription_setting=true, AutoChurnSubscriptionSetting should be included
+	if retrieved.AutoChurnSubscriptionSetting == nil {
+		t.Errorf("Expected AutoChurnSubscriptionSetting to be included when with_auto_churn_subscription_setting=true")
+	}
+
+	// When with_invoice_handling_setting=true, InvoiceHandlingSetting should be included
+	if retrieved.InvoiceHandlingSetting == nil {
+		t.Errorf("Expected InvoiceHandlingSetting to be included when with_invoice_handling_setting=true")
+	}
+
+	// Test with parameters set to false
+	params = &ExtraDataSourceParams{
+		WithProcessingStatus:             &falseBool,
+		WithAutoChurnSubscriptionSetting: &falseBool,
+		WithInvoiceHandlingSetting:       &falseBool,
+	}
+
+	retrieved, err = api.RetrieveDataSource(ds.UUID, params)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if retrieved.UUID != ds.UUID {
+		t.Errorf("Data source UUIDs don't match - expected: %v, actual: %v", ds.UUID, retrieved.UUID)
+	}
+
+	// Test with partial parameters - only processing status
+	params = &ExtraDataSourceParams{
+		WithProcessingStatus: &trueBool,
+	}
+
+	retrieved, err = api.RetrieveDataSource(ds.UUID, params)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if retrieved.UUID != ds.UUID {
+		t.Errorf("Data source UUIDs don't match - expected: %v, actual: %v", ds.UUID, retrieved.UUID)
+	}
+
+	// Test with mixed parameters
+	params = &ExtraDataSourceParams{
+		WithProcessingStatus:       &trueBool,
+		WithInvoiceHandlingSetting: &falseBool,
+	}
+
+	retrieved, err = api.RetrieveDataSource(ds.UUID, params)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if retrieved.UUID != ds.UUID {
+		t.Errorf("Data source UUIDs don't match - expected: %v, actual: %v", ds.UUID, retrieved.UUID)
+	}
+
+	// Test backward compatibility - no parameters (can be omitted now)
+	retrieved, err = api.RetrieveDataSource(ds.UUID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if retrieved.UUID != ds.UUID {
+		t.Errorf("Data source UUIDs don't match - expected: %v, actual: %v", ds.UUID, retrieved.UUID)
+	}
+
+	// Test with nil parameters
+	retrieved, err = api.RetrieveDataSource(ds.UUID, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if retrieved.UUID != ds.UUID {
+		t.Errorf("Data source UUIDs don't match - expected: %v, actual: %v", ds.UUID, retrieved.UUID)
+	}
+
+	log.Println("Data source retrieval with parameters tested successfully.")
+}
+
+// TestListDataSourcesWithExtraParams tests listing Data Sources with ExtraDataSourceParams.
+func TestListDataSourcesWithExtraParams(t *testing.T) {
+	if !*cm {
+		t.SkipNow()
+		return
+	}
+
+	ds, err := api.CreateDataSource(dsTestName)
+	if err != nil {
+		t.Error(err)
+	}
+	defer api.DeleteDataSource(ds.UUID)
+
+	trueBool := true
+	falseBool := false
+
+	// Test with all parameters
+	params := &ExtraDataSourceParams{
+		WithProcessingStatus:             &trueBool,
+		WithAutoChurnSubscriptionSetting: &trueBool,
+		WithInvoiceHandlingSetting:       &trueBool,
+	}
+
+	res, err := api.ListDataSources(params)
+	if err != nil {
+		t.Error(err)
+	}
+
+	found := false
+	for _, dataSource := range res.DataSources {
+		if dataSource.Name == dsTestName {
+			found = true
+			// When with_processing_status=true, ProcessingStatus should be included
+			if params.WithProcessingStatus != nil && *params.WithProcessingStatus {
+				if dataSource.ProcessingStatus == nil {
+					t.Errorf("Expected ProcessingStatus to be included when with_processing_status=true")
+				}
+			}
+			// When with_auto_churn_subscription_setting=true, AutoChurnSubscriptionSetting should be included
+			if params.WithAutoChurnSubscriptionSetting != nil && *params.WithAutoChurnSubscriptionSetting {
+				if dataSource.AutoChurnSubscriptionSetting == nil {
+					t.Errorf("Expected AutoChurnSubscriptionSetting to be included when with_auto_churn_subscription_setting=true")
+				}
+			}
+			// When with_invoice_handling_setting=true, InvoiceHandlingSetting should be included
+			if params.WithInvoiceHandlingSetting != nil && *params.WithInvoiceHandlingSetting {
+				if dataSource.InvoiceHandlingSetting == nil {
+					t.Errorf("Expected InvoiceHandlingSetting to be included when with_invoice_handling_setting=true")
+				}
+			}
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Data source not found in listing with extra params! %+v", res)
+	}
+
+	// Test with parameters set to false
+	params.WithProcessingStatus = &falseBool
+	params.WithAutoChurnSubscriptionSetting = &falseBool
+	params.WithInvoiceHandlingSetting = &falseBool
+
+	res, err = api.ListDataSources(params)
+	if err != nil {
+		t.Error(err)
+	}
+
+	found = false
+	for _, dataSource := range res.DataSources {
+		if dataSource.Name == dsTestName {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Data source not found in listing with false extra params! %+v", res)
+	}
+
+	log.Println("Data sources listing with ExtraDataSourceParams tested successfully.")
+}

--- a/datasources_test.go
+++ b/datasources_test.go
@@ -67,7 +67,7 @@ func TestListDataSourcesWithParams(t *testing.T) {
 
 	// Test with all parameters
 	params := &ListDataSourcesParams{
-		Name:   dsTestName,
+		Name: dsTestName,
 		ExtraDataSourceParams: ExtraDataSourceParams{
 			WithProcessingStatus:             &trueBool,
 			WithAutoChurnSubscriptionSetting: &trueBool,

--- a/datasources_test.go
+++ b/datasources_test.go
@@ -67,10 +67,12 @@ func TestListDataSourcesWithParams(t *testing.T) {
 
 	// Test with all parameters
 	params := &ListDataSourcesParams{
-		Name:                             dsTestName,
-		WithProcessingStatus:             &trueBool,
-		WithAutoChurnSubscriptionSetting: &trueBool,
-		WithInvoiceHandlingSetting:       &trueBool,
+		Name:   dsTestName,
+		ExtraDataSourceParams: ExtraDataSourceParams{
+			WithProcessingStatus:             &trueBool,
+			WithAutoChurnSubscriptionSetting: &trueBool,
+			WithInvoiceHandlingSetting:       &trueBool,
+		},
 	}
 
 	res, err := api.ListDataSourcesWithFilters(params)

--- a/generic.go
+++ b/generic.go
@@ -88,6 +88,32 @@ func (api API) retrieve(path string, uuid string, output interface{}) error {
 	return wrapErrors(res, body, errs)
 }
 
+// RETRIEVE WITH PARAMS
+func (api API) retrieveWithParams(path string, uuid string, output interface{}, params interface{}) error {
+	var res gorequest.Response
+	var body []byte
+	var errs []error
+	if uuid != "" {
+		path = strings.Replace(path, ":uuid", uuid, 1)
+	}
+
+	// nolint:errcheck
+	backoff.Retry(func() error {
+		req := api.req(gorequest.New().Get(prepareURL(path)))
+		if params != nil {
+			req.Query(params)
+		}
+		res, body, errs = req.EndStruct(output)
+
+		if networkErrors(errs) || isHTTPStatusRetryable(res) {
+			return errRetry
+		}
+		return nil
+	}, backoff.NewExponentialBackOff())
+
+	return wrapErrors(res, body, errs)
+}
+
 // UPDATE
 func (api API) merge(path string, input interface{}) error {
 	var res gorequest.Response

--- a/integration_tests/opportunities_test.go
+++ b/integration_tests/opportunities_test.go
@@ -46,7 +46,7 @@ func TestOpportunitiesIntegration(t *testing.T) {
 	}
 
 	newOpportunityParams := &cm.NewOpportunity{
-		CustomerUUID: cus1.UUID,
+		CustomerUUID:       cus1.UUID,
 		Owner:              "kamil+pavlicko@chartmogul.com",
 		Pipeline:           "New Business",
 		PipelineStage:      "Discovery",
@@ -59,7 +59,7 @@ func TestOpportunitiesIntegration(t *testing.T) {
 		Custom: []cm.Custom{
 			{
 				Key:   "from_campaign",
-				Value:  true,
+				Value: true,
 			},
 		},
 	}
@@ -113,7 +113,7 @@ func TestOpportunitiesIntegration(t *testing.T) {
 	}
 
 	otherOpportunityParams := &cm.NewOpportunity{
-		CustomerUUID: cus1.UUID,
+		CustomerUUID:       cus1.UUID,
 		Owner:              "kamil+pavlicko@chartmogul.com",
 		Pipeline:           "New Business",
 		PipelineStage:      "Discovery",

--- a/mock_chartmogul/chartmogul.go
+++ b/mock_chartmogul/chartmogul.go
@@ -460,18 +460,22 @@ func (mr *MockIApiMockRecorder) ListCustomersContacts(arg0, arg1 interface{}) *g
 }
 
 // ListDataSources mocks base method.
-func (m *MockIApi) ListDataSources() (*chartmogul.DataSources, error) {
+func (m *MockIApi) ListDataSources(params ...*chartmogul.ExtraDataSourceParams) (*chartmogul.DataSources, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDataSources")
+	varargs := []interface{}{}
+	for _, a := range params {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListDataSources", varargs...)
 	ret0, _ := ret[0].(*chartmogul.DataSources)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListDataSources indicates an expected call of ListDataSources.
-func (mr *MockIApiMockRecorder) ListDataSources() *gomock.Call {
+func (mr *MockIApiMockRecorder) ListDataSources(params ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDataSources", reflect.TypeOf((*MockIApi)(nil).ListDataSources))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDataSources", reflect.TypeOf((*MockIApi)(nil).ListDataSources), params...)
 }
 
 // ListDataSourcesWithFilters mocks base method.


### PR DESCRIPTION
Updates the [List Sources](https://dev.chartmogul.com/reference/sources/list/) and [Retrieve a Source](https://dev.chartmogul.com/reference/sources/retrieve/) to support requesting additional fields with the following query params:

- `with_processing_status=true`
- `with_auto_churn_subscription_setting=true`
- `with_invoice_handling_setting=true`

Using SDK code:

**1) [List Sources](https://dev.chartmogul.com/reference/sources/list/)**

```go
extraParams := &cm.ExtraDataSourceParams{
    WithProcessingStatus: &trueBool,
    WithAutoChurnSubscriptionSetting: &trueBool,
    WithInvoiceHandlingSetting: &trueBool,
}
api.ListDataSources(extraParams)

listParams := &cm.ListDataSourcesParams{
    Name: "stripe",
    System: "stripe",
    WithProcessingStatus: &trueBool,
    WithInvoiceHandlingSetting: &trueBool,
}
api.ListDataSourcesWithFilters(listParams)
```

**2) [Retrieve a Source](https://dev.chartmogul.com/reference/sources/retrieve/)**

```go
extraParams := &cm.ExtraDataSourceParams{
    WithProcessingStatus: &trueBool,
    WithAutoChurnSubscriptionSetting: &trueBool,
    WithInvoiceHandlingSetting: &trueBool,
}
api.RetrieveDataSource("uuid", extraParams)
```