### PR TITLE
Add new subscriptions list, connect and disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ api.ListCustomers(&cm.ListCustomersParams{})
 api.UpdateCustomer(&cm.NewCustomer{}, "customerUUID")
 api.MergeCustomers(&cm.MergeCustomersParams{})
 api.UnmergeCustomers(&cm.UnmergeCustomersParams{})
+// DEPRECATED: Use api.MetricsConnectSubscriptions instead
 api.ConnectSubscriptions("customerUUID", []cm.Subscription{})
+// DEPRECATED: Use api.MetricsDisconnectSubscriptions instead
 api.DisconnectSubscriptions("customerUUID", []cm.Subscription{})
 api.ListCustomersContact(&cm.ListContactsParams{}, "customerUUID")
 api.CreateCustomersContact(&cm.NewContact{}, "customerUUID")
@@ -225,7 +227,13 @@ api.CreateTransaction(&cm.Transaction{}, "invoiceUUID")
 ```go
 api.CancelSubscription("subscriptionUUID", &cm.CancelSubscriptionParams{CancelledAt: "2005-01-01T01:02:03.000Z"})
 api.CancelSubscription("subscriptionUUID", &cm.CancelSubscriptionParams{CancellationDates: []string{"2005-01-01T01:02:03.000Z", "2006-10-21T11:21:13.000Z"}})
+// DEPRECATED: Use api.MetricsListCustomerSubscriptions instead
 api.ListSubscriptions(&cm.Cursor{}, "customerUUID")
+
+// Recommended: Use Metrics API for subscriptions
+api.MetricsListCustomerSubscriptions(&cm.Cursor{}, "customerUUID")
+api.MetricsConnectSubscriptions("dataSourceUUID", "customerUUID", []*cm.MetricsCustomerSubscription{})
+api.MetricsDisconnectSubscriptions("dataSourceUUID", "customerUUID", []*cm.MetricsCustomerSubscription{})
 ```
 
 #### [Customer Attributes](https://dev.chartmogul.com/reference/customers/attributes/)

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -80,6 +80,8 @@ type IApi interface {
 	// Subscriptions
 	CancelSubscription(subscriptionUUID string, cancelSubscriptionParams *CancelSubscriptionParams) (*Subscription, error)
 	ListSubscriptions(cursor *Cursor, customerUUID string) (*Subscriptions, error)
+	ConnectSubscriptions(customerUUID string, subscriptions []Subscription) error
+	DisconnectSubscriptions(customerUUID string, subscriptions []Subscription) error
 	// Transactions
 	CreateTransaction(transaction *Transaction, invoiceUUID string) (*Transaction, error)
 
@@ -151,6 +153,8 @@ type IApi interface {
 
 	// Metrics - Subscriptions & Activities
 	MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID string) (*MetricsCustomerSubscriptions, error)
+	MetricsConnectSubscriptions(dataSourceUUID string, customerUUID string, subscriptions []*MetricsCustomerSubscription) error
+	MetricsDisconnectSubscriptions(dataSourceUUID string, customerUUID string, subscriptions []*MetricsCustomerSubscription) error
 	MetricsListCustomerActivities(cursor *Cursor, customerUUID string) (*MetricsCustomerActivities, error)
 	MetricsListActivities(MetricsListActivitiesParams *MetricsListActivitiesParams) (*MetricsActivities, error)
 	MetricsCreateActivitiesExport(CreateMetricsActivitiesExportParam *CreateMetricsActivitiesExportParam) (*MetricsActivitiesExport, error)

--- a/metrics_customer_subscriptions.go
+++ b/metrics_customer_subscriptions.go
@@ -17,12 +17,24 @@ type MetricsCustomerSubscription struct {
 	EndDate           string  `json:"end-date"`
 	Currency          string  `json:"currency"`
 	CurrencySign      string  `json:"currency-sign"`
+	UUID              string  `json:"uuid,omitempty"` // UUID field for connect/disconnect operations
 }
 
 // MetricsCustomerSubscriptions is the result of listing subscriptions in Metrics API.
 type MetricsCustomerSubscriptions struct {
 	Entries []*MetricsCustomerSubscription `json:"entries"`
 	Pagination
+}
+
+// MetricsConnectSubscriptionsParams represents subscriptions data for connect/disconnect operations.
+type MetricsConnectSubscriptionsParams struct {
+	Subscriptions []MetricsSubscriptionReference `json:"subscriptions"`
+}
+
+// MetricsSubscriptionReference represents a minimal subscription reference with UUID and data source.
+type MetricsSubscriptionReference struct {
+	UUID           string `json:"uuid"`
+	DataSourceUUID string `json:"data_source_uuid"`
 }
 
 const metricsCustomerSubscriptionsEndpoint = "customers/:uuid/subscriptions"
@@ -38,4 +50,40 @@ func (api API) MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID str
 		query = append(query, *cursor)
 	}
 	return result, api.list(path, result, query...)
+}
+
+// MetricsConnectSubscriptions connects subscription objects for a customer.
+//
+// See https://dev.chartmogul.com/reference#connect-subscriptions
+func (api API) MetricsConnectSubscriptions(dataSourceUUID string, customerUUID string, subscriptions []*MetricsCustomerSubscription) error {
+	path := strings.Replace(connectSubscriptionEndpoint, ":uuid", customerUUID, 1)
+
+	refs := make([]MetricsSubscriptionReference, len(subscriptions))
+	for i, sub := range subscriptions {
+		refs[i] = MetricsSubscriptionReference{
+			UUID:           sub.UUID,
+			DataSourceUUID: dataSourceUUID,
+		}
+	}
+
+	return api.merge(path, MetricsConnectSubscriptionsParams{
+		Subscriptions: refs,
+	})
+}
+
+// MetricsDisconnectSubscriptions disconnects subscription objects for a customer.
+func (api API) MetricsDisconnectSubscriptions(dataSourceUUID string, customerUUID string, subscriptions []*MetricsCustomerSubscription) error {
+	path := strings.Replace(disconnectSubscriptionEndpoint, ":uuid", customerUUID, 1)
+
+	refs := make([]MetricsSubscriptionReference, len(subscriptions))
+	for i, sub := range subscriptions {
+		refs[i] = MetricsSubscriptionReference{
+			UUID:           sub.UUID,
+			DataSourceUUID: dataSourceUUID,
+		}
+	}
+
+	return api.merge(path, MetricsConnectSubscriptionsParams{
+		Subscriptions: refs,
+	})
 }

--- a/metrics_customer_subscriptions.go
+++ b/metrics_customer_subscriptions.go
@@ -41,7 +41,7 @@ const metricsCustomerSubscriptionsEndpoint = "customers/:uuid/subscriptions"
 
 // MetricsListCustomerSubscriptions lists all subscriptions for customer of a given UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#list-customer-subscriptions
+// See https://dev.chartmogul.com/reference/subscriptions/list
 func (api API) MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID string) (*MetricsCustomerSubscriptions, error) {
 	result := &MetricsCustomerSubscriptions{}
 	path := strings.Replace(metricsCustomerSubscriptionsEndpoint, ":uuid", customerUUID, 1)
@@ -54,7 +54,7 @@ func (api API) MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID str
 
 // MetricsConnectSubscriptions connects subscription objects for a customer.
 //
-// See https://dev.chartmogul.com/reference#connect-subscriptions
+// See https://dev.chartmogul.com/reference/subscriptions/connect
 func (api API) MetricsConnectSubscriptions(dataSourceUUID string, customerUUID string, subscriptions []*MetricsCustomerSubscription) error {
 	path := strings.Replace(connectSubscriptionEndpoint, ":uuid", customerUUID, 1)
 
@@ -72,6 +72,8 @@ func (api API) MetricsConnectSubscriptions(dataSourceUUID string, customerUUID s
 }
 
 // MetricsDisconnectSubscriptions disconnects subscription objects for a customer.
+//
+// See https://dev.chartmogul.com/reference/subscriptions/disconnect
 func (api API) MetricsDisconnectSubscriptions(dataSourceUUID string, customerUUID string, subscriptions []*MetricsCustomerSubscription) error {
 	path := strings.Replace(disconnectSubscriptionEndpoint, ":uuid", customerUUID, 1)
 

--- a/metrics_customer_subscriptions_test.go
+++ b/metrics_customer_subscriptions_test.go
@@ -58,3 +58,69 @@ func TestListCustomerSubscriptions(t *testing.T) {
 		t.Fatal("Unexpected result")
 	}
 }
+
+// Test MetricsConnectSubscriptions
+func TestMetricsConnectSubscriptions(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "POST" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/customers/cus_8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7/connect_subscriptions" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+
+	subscriptions := []*MetricsCustomerSubscription{
+		{UUID: "sub_uuid_1"},
+		{UUID: "sub_uuid_2"},
+	}
+
+	err := tested.MetricsConnectSubscriptions("ds_uuid", "cus_8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7", subscriptions)
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+}
+
+// Test MetricsDisconnectSubscriptions
+func TestMetricsDisconnectSubscriptions(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "POST" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				if r.RequestURI != "/v/customers/cus_8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7/disconnect_subscriptions" {
+					t.Errorf("Unexpected URI %v", r.RequestURI)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+
+	subscriptions := []*MetricsCustomerSubscription{
+		{UUID: "sub_uuid_1"},
+		{UUID: "sub_uuid_2"},
+	}
+
+	err := tested.MetricsDisconnectSubscriptions("ds_uuid", "cus_8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7", subscriptions)
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+}

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -45,7 +45,7 @@ func (api API) CancelSubscription(subscriptionUUID string, cancelSubscriptionPar
 		result)
 }
 
-// ListSubscriptions lists all subscriptions for cutomer of given UUID.
+// ListSubscriptions lists all subscriptions for customer of given UUID.
 // DEPRECATED: Use MetricsListCustomerSubscriptions instead.
 func (api API) ListSubscriptions(cursor *Cursor, customerUUID string) (*Subscriptions, error) {
 	result := &Subscriptions{}

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -1,6 +1,7 @@
 package chartmogul
 
 import (
+	"log"
 	"strings"
 )
 
@@ -45,8 +46,7 @@ func (api API) CancelSubscription(subscriptionUUID string, cancelSubscriptionPar
 }
 
 // ListSubscriptions lists all subscriptions for cutomer of given UUID.
-//
-// See https://dev.chartmogul.com/v1.0/reference#subscriptions
+// DEPRECATED: Use MetricsListCustomerSubscriptions instead.
 func (api API) ListSubscriptions(cursor *Cursor, customerUUID string) (*Subscriptions, error) {
 	result := &Subscriptions{}
 	path := strings.Replace(subscriptionsEndpoint, ":customerUUID", customerUUID, 1)
@@ -58,19 +58,19 @@ func (api API) ListSubscriptions(cursor *Cursor, customerUUID string) (*Subscrip
 }
 
 // ConnectSubscriptions connects two subscription objects
-//
-// See https://dev.chartmogul.com/reference#connect-subscriptions
+// DEPRECATED: Use MetricsConnectSubscriptions instead.
 func (api API) ConnectSubscriptions(customerUUID string, subscriptions []Subscription) error {
+	log.Println("[DEPRECATED] ConnectSubscriptions is deprecated. Use MetricsConnectSubscriptions instead.")
 	path := strings.Replace(connectSubscriptionEndpoint, ":uuid", customerUUID, 1)
 	return api.merge(path, Subscriptions{
 		Subscriptions: subscriptions,
 	})
 }
 
-// DisconnectSubscriptions connects two subscription objects
-//
-// See https://dev.chartmogul.com/reference#disconnect-subscriptions
+// DisconnectSubscriptions disconnects two subscription objects
+// DEPRECATED: Use MetricsDisconnectSubscriptions instead.
 func (api API) DisconnectSubscriptions(customerUUID string, subscriptions []Subscription) error {
+	log.Println("[DEPRECATED] DisconnectSubscriptions is deprecated. Use MetricsDisconnectSubscriptions instead.")
 	path := strings.Replace(disconnectSubscriptionEndpoint, ":uuid", customerUUID, 1)
 	return api.merge(path, Subscriptions{
 		Subscriptions: subscriptions,


### PR DESCRIPTION
Deprecated Methods (with code comments):
- `ListSubscriptions()` - use `MetricsListCustomerSubscriptions()` instead
- `ConnectSubscriptions()` - use `MetricsConnectSubscriptions()` instead (prints warning to stderr)
- `DisconnectSubscriptions()` - use `MetricsDisconnectSubscriptions()` instead (prints warning to stderr)
  
New Methods:
- `MetricsConnectSubscriptions(dataSourceUUID, customerUUID, subscriptions)` 
- `MetricsDisconnectSubscriptions(dataSourceUUID, customerUUID, subscriptions)`
  