### PR TITLE
Add External ID Field to Contact Model

### DIFF
--- a/contacts.go
+++ b/contacts.go
@@ -17,6 +17,8 @@ type Contact struct {
 	Position           uint32                 `json:"position,omitempty"`
 	Title              string                 `json:"title,omitempty"`
 	Twitter            string                 `json:"twitter,omitempty"`
+	// Using *string allows callers to explicitly clear this field
+	// Passing nil means omit the field; passing "" means clear the field
 	ExternalID         *string                `json:"external_id,omitempty"`
 	Custom             map[string]interface{} `json:"custom,omitempty"`
 }
@@ -25,7 +27,6 @@ type Contact struct {
 type UpdateContact struct {
 	CustomerExternalID string   `json:"customer_external_id,omitempty"`
 	DataSourceUUID     string   `json:"data_source_uuid,omitempty"`
-	ExternalID         *string  `json:"external_id,omitempty"`
 	FirstName          string   `json:"first_name,omitempty"`
 	LastName           string   `json:"last_name,omitempty"`
 	LinkedIn           string   `json:"linked_in,omitempty"`
@@ -34,6 +35,9 @@ type UpdateContact struct {
 	Position           uint32   `json:"position,omitempty"`
 	Title              string   `json:"title,omitempty"`
 	Twitter            string   `json:"twitter,omitempty"`
+	// Using *string allows callers to explicitly clear this field
+	// Passing nil means omit the field; passing "" means clear the field
+	ExternalID         *string  `json:"external_id,omitempty"`
 	Custom             []Custom `json:"custom,omitempty"`
 }
 
@@ -43,8 +47,7 @@ type NewContact struct {
 	CustomerUUID   string `json:"customer_uuid,omitempty"`
 	DataSourceUUID string `json:"data_source_uuid,omitempty"`
 
-	//Optional
-	ExternalID *string  `json:"external_id,omitempty"`
+	// Optional
 	FirstName  string   `json:"first_name,omitempty"`
 	LastName   string   `json:"last_name,omitempty"`
 	LinkedIn   string   `json:"linked_in,omitempty"`
@@ -53,6 +56,9 @@ type NewContact struct {
 	Position   uint32   `json:"position,omitempty"`
 	Title      string   `json:"title,omitempty"`
 	Twitter    string   `json:"twitter,omitempty"`
+	// Using *string allows callers to explicitly clear this field
+	// Passing nil means omit the field; passing "" means clear the field
+	ExternalID *string  `json:"external_id,omitempty"`
 	Custom     []Custom `json:"custom,omitempty"`
 }
 

--- a/contacts.go
+++ b/contacts.go
@@ -17,6 +17,7 @@ type Contact struct {
 	Position           uint32                 `json:"position,omitempty"`
 	Title              string                 `json:"title,omitempty"`
 	Twitter            string                 `json:"twitter,omitempty"`
+	ExternalID         *string                `json:"external_id,omitempty"`
 	Custom             map[string]interface{} `json:"custom,omitempty"`
 }
 
@@ -24,6 +25,7 @@ type Contact struct {
 type UpdateContact struct {
 	CustomerExternalID string   `json:"customer_external_id,omitempty"`
 	DataSourceUUID     string   `json:"data_source_uuid,omitempty"`
+	ExternalID         *string  `json:"external_id,omitempty"`
 	FirstName          string   `json:"first_name,omitempty"`
 	LastName           string   `json:"last_name,omitempty"`
 	LinkedIn           string   `json:"linked_in,omitempty"`
@@ -42,15 +44,16 @@ type NewContact struct {
 	DataSourceUUID string `json:"data_source_uuid,omitempty"`
 
 	//Optional
-	FirstName string   `json:"first_name,omitempty"`
-	LastName  string   `json:"last_name,omitempty"`
-	LinkedIn  string   `json:"linked_in,omitempty"`
-	Notes     string   `json:"notes,omitempty"`
-	Phone     string   `json:"phone,omitempty"`
-	Position  uint32   `json:"position,omitempty"`
-	Title     string   `json:"title,omitempty"`
-	Twitter   string   `json:"twitter,omitempty"`
-	Custom    []Custom `json:"custom,omitempty"`
+	ExternalID *string  `json:"external_id,omitempty"`
+	FirstName  string   `json:"first_name,omitempty"`
+	LastName   string   `json:"last_name,omitempty"`
+	LinkedIn   string   `json:"linked_in,omitempty"`
+	Notes      string   `json:"notes,omitempty"`
+	Phone      string   `json:"phone,omitempty"`
+	Position   uint32   `json:"position,omitempty"`
+	Title      string   `json:"title,omitempty"`
+	Twitter    string   `json:"twitter,omitempty"`
+	Custom     []Custom `json:"custom,omitempty"`
 }
 
 // ListContactsParams = parameters for listing contacts in API.

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -130,6 +130,7 @@ func TestCreateContact(t *testing.T) {
 					"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
 					"customer_external_id": "customer_001",
 					"data_source_uuid": "ds_00000000-0000-0000-0000-000000000000",
+					"external_id": "contact_external_id_001",
 					"position": 9,
 					"first_name": "Adam",
 					"last_name": "Smith",
@@ -152,9 +153,11 @@ func TestCreateContact(t *testing.T) {
 		ApiKey: "token",
 	}
 
+	externalID := "contact_external_id_001"
 	contact, err := tested.CreateContact(&NewContact{
 		CustomerUUID:   "cus_00000000-0000-0000-0000-000000000000",
 		DataSourceUUID: "ds_00000000-0000-0000-0000-000000000000",
+		ExternalID:     &externalID,
 		FirstName:      "Adam",
 		LastName:       "Smith",
 		LinkedIn:       "https://linkedin.com/linkedin",
@@ -183,6 +186,91 @@ func TestCreateContact(t *testing.T) {
 		spew.Dump(contact)
 		t.Fatal("Unexpected result")
 	}
+	if contact.ExternalID == nil || *contact.ExternalID != "contact_external_id_001" {
+		spew.Dump(contact)
+		t.Fatal("Unexpected ExternalID")
+	}
+}
+
+func TestCreateContactWithNullExternalID(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "POST" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				w.WriteHeader(http.StatusCreated)
+				//nolint
+				w.Write([]byte(`{
+					"uuid": "con_00000000-0000-0000-0000-000000000000",
+					"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+					"data_source_uuid": "ds_00000000-0000-0000-0000-000000000000",
+					"external_id": null
+				}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+	}
+
+	contact, err := tested.CreateContact(&NewContact{
+		CustomerUUID:   "cus_00000000-0000-0000-0000-000000000000",
+		DataSourceUUID: "ds_00000000-0000-0000-0000-000000000000",
+		ExternalID:     nil,
+	})
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if contact.ExternalID != nil {
+		spew.Dump(contact)
+		t.Fatal("Expected ExternalID to be nil")
+	}
+}
+
+// Note: Since ExternalID *string with omitempty serializes nil as an omitted field, both the
+// TestCreateContactWithNullExternalID test case above and this test case are structurally identical
+// from a serialization standpoint. They exist to document intent: (a) field can be absent and
+// (b) field can be explicitly null. Both verify the response parses null correctly.
+func TestCreateContactWithoutExternalID(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "POST" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				w.WriteHeader(http.StatusCreated)
+				//nolint
+				w.Write([]byte(`{
+					"uuid": "con_00000000-0000-0000-0000-000000000000",
+					"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+					"data_source_uuid": "ds_00000000-0000-0000-0000-000000000000",
+					"external_id": null
+				}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+	}
+
+	contact, err := tested.CreateContact(&NewContact{
+		CustomerUUID:   "cus_00000000-0000-0000-0000-000000000000",
+		DataSourceUUID: "ds_00000000-0000-0000-0000-000000000000",
+	})
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if contact.ExternalID != nil {
+		spew.Dump(contact)
+		t.Fatal("Expected ExternalID to be nil")
+	}
 }
 
 func TestUpdateContact(t *testing.T) {
@@ -202,6 +290,7 @@ func TestUpdateContact(t *testing.T) {
 					"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
 					"customer_external_id": "customer_001",
 					"data_source_uuid": "ds_00000000-0000-0000-0000-000000000000",
+					"external_id": "contact_external_id_002",
 					"position": 10,
 					"first_name": "Bill",
 					"last_name": "Thompson",
@@ -224,15 +313,17 @@ func TestUpdateContact(t *testing.T) {
 		ApiKey: "token",
 	}
 
+	externalID := "contact_external_id_002"
 	contact, err := tested.UpdateContact(&UpdateContact{
-		FirstName: "Bill",
-		LastName:  "Thompson",
-		LinkedIn:  "https://linkedin.com/bill-linkedin",
-		Notes:     "New Heading\nNew Body\nNew Footer",
-		Phone:     "+987654321",
-		Position:  10,
-		Title:     "CTO",
-		Twitter:   "https://twitter.com/bill-twitter",
+		ExternalID: &externalID,
+		FirstName:  "Bill",
+		LastName:   "Thompson",
+		LinkedIn:   "https://linkedin.com/bill-linkedin",
+		Notes:      "New Heading\nNew Body\nNew Footer",
+		Phone:      "+987654321",
+		Position:   10,
+		Title:      "CTO",
+		Twitter:    "https://twitter.com/bill-twitter",
 		Custom: []Custom{
 			{
 				Key:   "Facebook",
@@ -252,6 +343,47 @@ func TestUpdateContact(t *testing.T) {
 	if contact.FirstName != "Bill" {
 		spew.Dump(contact)
 		t.Fatal("Unexpected result")
+	}
+	if contact.ExternalID == nil || *contact.ExternalID != "contact_external_id_002" {
+		spew.Dump(contact)
+		t.Fatal("Unexpected ExternalID")
+	}
+}
+
+func TestUpdateContactWithNullExternalID(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "PATCH" {
+					t.Errorf("Unexpected method %v", r.Method)
+				}
+				w.WriteHeader(http.StatusOK)
+				//nolint
+				w.Write([]byte(`{
+					"uuid": "con_00000000-0000-0000-0000-000000000000",
+					"customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+					"data_source_uuid": "ds_00000000-0000-0000-0000-000000000000",
+					"external_id": null
+				}`))
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+	}
+
+	contact, err := tested.UpdateContact(&UpdateContact{
+		ExternalID: nil,
+	}, "con_00000000-0000-0000-0000-000000000000")
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if contact.ExternalID != nil {
+		spew.Dump(contact)
+		t.Fatal("Expected ExternalID to be nil")
 	}
 }
 


### PR DESCRIPTION
This PR updates the Contact model to include the `external_id` field. The `external_id` field can be either a string or null. The Contact model tests have been updated to demonstrate how the `external_id` field can be set in both CREATE and UPDATE requests.