### PR TITLE
Backport new features to v4 (non-breaking)

### DIFF
--- a/account.go
+++ b/account.go
@@ -1,6 +1,9 @@
 package chartmogul
 
-import "strings"
+import (
+	neturl "net/url"
+	"strings"
+)
 
 const (
 	accountEndpoint = "account"
@@ -34,7 +37,7 @@ func (api API) RetrieveAccount(params ...*RetrieveAccountParams) (*Account, erro
 		fields := params[0].Include
 		// Normalize array-style input
 		fields = strings.ReplaceAll(fields, " ", "")
-		path := accountEndpoint + "?include=" + fields
+		path := accountEndpoint + "?include=" + neturl.QueryEscape(fields)
 		return result, api.retrieve(path, "", result)
 	}
 	return result, api.retrieve(accountEndpoint, "", result)

--- a/account.go
+++ b/account.go
@@ -1,20 +1,41 @@
 package chartmogul
 
+import "strings"
+
 const (
 	accountEndpoint = "account"
 )
 
 // Account details in ChartMogul
 type Account struct {
-	Name        string `json:"name"`
-	Currency    string `json:"currency"`
-	TimeZone    string `json:"time_zone"`
-	WeekStartOn string `json:"week_start_on"`
+	ID                                string      `json:"id,omitempty"`
+	Name                              string      `json:"name"`
+	Currency                          string      `json:"currency"`
+	TimeZone                          string      `json:"time_zone"`
+	WeekStartOn                       string      `json:"week_start_on"`
+	ChurnRecognition                  interface{} `json:"churn_recognition,omitempty"`
+	ChurnWhenZeroMRR                  interface{} `json:"churn_when_zero_mrr,omitempty"`
+	AutoChurnSubscription             interface{} `json:"auto_churn_subscription,omitempty"`
+	RefundHandling                    interface{} `json:"refund_handling,omitempty"`
+	ProximateMovementReclassification interface{} `json:"proximate_movement_reclassification,omitempty"`
+}
+
+// RetrieveAccountParams optional parameters for RetrieveAccount.
+type RetrieveAccountParams struct {
+	Include string `json:"include,omitempty"`
 }
 
 // RetrieveAccount returns details of current account.
-func (api API) RetrieveAccount() (*Account, error) {
+// Optionally accepts RetrieveAccountParams with an Include field
+// (comma-separated list: churn_recognition, churn_when_zero_mrr, etc.)
+func (api API) RetrieveAccount(params ...*RetrieveAccountParams) (*Account, error) {
 	result := &Account{}
-	accountUUID := ""
-	return result, api.retrieve(accountEndpoint, accountUUID, result)
+	if len(params) > 0 && params[0] != nil && params[0].Include != "" {
+		fields := params[0].Include
+		// Normalize array-style input
+		fields = strings.ReplaceAll(fields, " ", "")
+		path := accountEndpoint + "?include=" + fields
+		return result, api.retrieve(path, "", result)
+	}
+	return result, api.retrieve(accountEndpoint, "", result)
 }

--- a/account_test.go
+++ b/account_test.go
@@ -9,10 +9,21 @@ import (
 )
 
 const accountExample = `{
+	"id": "acc_12345",
 	"name": "Example Test Company",
 	"currency": "EUR",
 	"time_zone": "Europe/Berlin",
 	"week_start_on": "sunday"
+}`
+
+const accountWithIncludeExample = `{
+	"id": "acc_12345",
+	"name": "Example Test Company",
+	"currency": "EUR",
+	"time_zone": "Europe/Berlin",
+	"week_start_on": "sunday",
+	"churn_recognition": {"mode": "at_period_end"},
+	"churn_when_zero_mrr": {"enabled": true}
 }`
 
 func TestRetrieveAccount(t *testing.T) {
@@ -39,9 +50,50 @@ func TestRetrieveAccount(t *testing.T) {
 	}
 	account, err := tested.RetrieveAccount()
 
-	if account.Name != "Example Test Company" || account.Currency != "EUR" || account.TimeZone != "Europe/Berlin" || account.WeekStartOn != "sunday" {
+	if account.ID != "acc_12345" || account.Name != "Example Test Company" || account.Currency != "EUR" || account.TimeZone != "Europe/Berlin" || account.WeekStartOn != "sunday" {
 		spew.Dump(account)
 		t.Error("Unexpected account details")
+	}
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+}
+
+func TestRetrieveAccountWithInclude(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "GET"
+				if r.Method != expectedMethod {
+					t.Errorf("Requested method expected: %v, actual: %v", expectedMethod, r.Method)
+				}
+				// Check include query param
+				include := r.URL.Query().Get("include")
+				if include != "churn_recognition,churn_when_zero_mrr" {
+					t.Errorf("Expected include param, got: %v", include)
+				}
+				w.Write([]byte(accountWithIncludeExample)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	account, err := tested.RetrieveAccount(&RetrieveAccountParams{
+		Include: "churn_recognition,churn_when_zero_mrr",
+	})
+
+	if account.ID != "acc_12345" || account.Name != "Example Test Company" {
+		spew.Dump(account)
+		t.Error("Unexpected account details")
+	}
+	if account.ChurnRecognition == nil {
+		t.Error("Expected churn_recognition to be present")
+	}
+	if account.ChurnWhenZeroMRR == nil {
+		t.Error("Expected churn_when_zero_mrr to be present")
 	}
 	if err != nil {
 		spew.Dump(err)

--- a/attributes.go
+++ b/attributes.go
@@ -47,7 +47,7 @@ const (
 
 // RetrieveCustomersAttributes returns attributes for given customer UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customer-attributes
+// See https://dev.chartmogul.com/reference/customer-attributes
 func (api API) RetrieveCustomersAttributes(customerUUID string) (*Attributes, error) {
 	output := &Attributes{}
 	err := api.retrieve(customersAttributesEndpoint, customerUUID, output)
@@ -56,7 +56,7 @@ func (api API) RetrieveCustomersAttributes(customerUUID string) (*Attributes, er
 
 // AddCustomAttributesToCustomer adds custom attributes to specific customer.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customer-attributes
+// See https://dev.chartmogul.com/reference/customer-attributes
 func (api API) AddCustomAttributesToCustomer(customerUUID string, customAttributes []*CustomAttribute) (*CustomAttributes, error) {
 	output := &CustomAttributes{}
 	err := api.add(customerCustomAttributesEndpoint,
@@ -68,7 +68,7 @@ func (api API) AddCustomAttributesToCustomer(customerUUID string, customAttribut
 
 // AddCustomAttributesWithEmail adds custom attributes to customers with specific email.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customer-attributes
+// See https://dev.chartmogul.com/reference/customer-attributes
 func (api API) AddCustomAttributesWithEmail(email string, customAttributes []*CustomAttribute) (*Customers, error) {
 	output := &Customers{}
 	err := api.create(customAttributesEndpoint,
@@ -79,7 +79,7 @@ func (api API) AddCustomAttributesWithEmail(email string, customAttributes []*Cu
 
 // UpdateCustomAttributesOfCustomer updates custom attributes of a specific customer.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customer-attributes
+// See https://dev.chartmogul.com/reference/customer-attributes
 func (api API) UpdateCustomAttributesOfCustomer(customerUUID string, customAttributes map[string]interface{}) (*CustomAttributes, error) {
 	output := &CustomAttributes{}
 	err := api.putTo(customerCustomAttributesEndpoint,
@@ -91,7 +91,7 @@ func (api API) UpdateCustomAttributesOfCustomer(customerUUID string, customAttri
 
 // RemoveCustomAttributes removes a list of custom attributes from a specific customer.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customer-attributes
+// See https://dev.chartmogul.com/reference/customer-attributes
 func (api API) RemoveCustomAttributes(customerUUID string, customAttributes []string) (*CustomAttributes, error) {
 	output := &CustomAttributes{}
 	err := api.deleteWhat(customerCustomAttributesEndpoint,

--- a/attributes.go
+++ b/attributes.go
@@ -46,7 +46,6 @@ const (
 )
 
 // RetrieveCustomersAttributes returns attributes for given customer UUID.
-//
 func (api API) RetrieveCustomersAttributes(customerUUID string) (*Attributes, error) {
 	output := &Attributes{}
 	err := api.retrieve(customersAttributesEndpoint, customerUUID, output)
@@ -54,7 +53,6 @@ func (api API) RetrieveCustomersAttributes(customerUUID string) (*Attributes, er
 }
 
 // AddCustomAttributesToCustomer adds custom attributes to specific customer.
-//
 func (api API) AddCustomAttributesToCustomer(customerUUID string, customAttributes []*CustomAttribute) (*CustomAttributes, error) {
 	output := &CustomAttributes{}
 	err := api.add(customerCustomAttributesEndpoint,
@@ -65,7 +63,6 @@ func (api API) AddCustomAttributesToCustomer(customerUUID string, customAttribut
 }
 
 // AddCustomAttributesWithEmail adds custom attributes to customers with specific email.
-//
 func (api API) AddCustomAttributesWithEmail(email string, customAttributes []*CustomAttribute) (*Customers, error) {
 	output := &Customers{}
 	err := api.create(customAttributesEndpoint,
@@ -75,7 +72,6 @@ func (api API) AddCustomAttributesWithEmail(email string, customAttributes []*Cu
 }
 
 // UpdateCustomAttributesOfCustomer updates custom attributes of a specific customer.
-//
 func (api API) UpdateCustomAttributesOfCustomer(customerUUID string, customAttributes map[string]interface{}) (*CustomAttributes, error) {
 	output := &CustomAttributes{}
 	err := api.putTo(customerCustomAttributesEndpoint,
@@ -86,7 +82,6 @@ func (api API) UpdateCustomAttributesOfCustomer(customerUUID string, customAttri
 }
 
 // RemoveCustomAttributes removes a list of custom attributes from a specific customer.
-//
 func (api API) RemoveCustomAttributes(customerUUID string, customAttributes []string) (*CustomAttributes, error) {
 	output := &CustomAttributes{}
 	err := api.deleteWhat(customerCustomAttributesEndpoint,

--- a/attributes.go
+++ b/attributes.go
@@ -47,7 +47,6 @@ const (
 
 // RetrieveCustomersAttributes returns attributes for given customer UUID.
 //
-// See https://dev.chartmogul.com/reference/customer-attributes
 func (api API) RetrieveCustomersAttributes(customerUUID string) (*Attributes, error) {
 	output := &Attributes{}
 	err := api.retrieve(customersAttributesEndpoint, customerUUID, output)
@@ -56,7 +55,6 @@ func (api API) RetrieveCustomersAttributes(customerUUID string) (*Attributes, er
 
 // AddCustomAttributesToCustomer adds custom attributes to specific customer.
 //
-// See https://dev.chartmogul.com/reference/customer-attributes
 func (api API) AddCustomAttributesToCustomer(customerUUID string, customAttributes []*CustomAttribute) (*CustomAttributes, error) {
 	output := &CustomAttributes{}
 	err := api.add(customerCustomAttributesEndpoint,
@@ -68,7 +66,6 @@ func (api API) AddCustomAttributesToCustomer(customerUUID string, customAttribut
 
 // AddCustomAttributesWithEmail adds custom attributes to customers with specific email.
 //
-// See https://dev.chartmogul.com/reference/customer-attributes
 func (api API) AddCustomAttributesWithEmail(email string, customAttributes []*CustomAttribute) (*Customers, error) {
 	output := &Customers{}
 	err := api.create(customAttributesEndpoint,
@@ -79,7 +76,6 @@ func (api API) AddCustomAttributesWithEmail(email string, customAttributes []*Cu
 
 // UpdateCustomAttributesOfCustomer updates custom attributes of a specific customer.
 //
-// See https://dev.chartmogul.com/reference/customer-attributes
 func (api API) UpdateCustomAttributesOfCustomer(customerUUID string, customAttributes map[string]interface{}) (*CustomAttributes, error) {
 	output := &CustomAttributes{}
 	err := api.putTo(customerCustomAttributesEndpoint,
@@ -91,7 +87,6 @@ func (api API) UpdateCustomAttributesOfCustomer(customerUUID string, customAttri
 
 // RemoveCustomAttributes removes a list of custom attributes from a specific customer.
 //
-// See https://dev.chartmogul.com/reference/customer-attributes
 func (api API) RemoveCustomAttributes(customerUUID string, customAttributes []string) (*CustomAttributes, error) {
 	output := &CustomAttributes{}
 	err := api.deleteWhat(customerCustomAttributesEndpoint,

--- a/chartmogul.go
+++ b/chartmogul.go
@@ -64,6 +64,8 @@ type IApi interface {
 	ListAllInvoices(listAllInvoicesParams *ListAllInvoicesParams) (*Invoices, error)
 	RetrieveInvoice(invoiceUUID string, params ...*RetrieveInvoiceParams) (*Invoice, error)
 	DeleteInvoice(invoiceUUID string) error
+	UpdateInvoiceStatus(dataSourceUUID, invoiceExternalID string, params *UpdateInvoiceStatusParams) error
+	ToggleInvoiceDisabled(invoiceUUID string, params *ToggleInvoiceDisabledParams) (*Invoice, error)
 	// Plans
 	CreatePlan(plan *Plan) (result *Plan, err error)
 	RetrievePlan(planUUID string) (*Plan, error)
@@ -161,19 +163,24 @@ type IApi interface {
 	MetricsRetrieveActivitiesExport(activitiesExportUUID string) (*MetricsActivitiesExport, error)
 
 	// Account
-	RetrieveAccount() (*Account, error)
+	RetrieveAccount(params ...*RetrieveAccountParams) (*Account, error)
 
 	// Subscription Events
 	ListSubscriptionEvents(filters *FilterSubscriptionEvents, cursor *Cursor) (*SubscriptionEvents, error)
 	CreateSubscriptionEvent(newSubscriptionEvent *SubscriptionEvent) (*SubscriptionEvent, error)
 	UpdateSubscriptionEvent(subscriptionEvent *SubscriptionEvent) (*SubscriptionEvent, error)
 	DeleteSubscriptionEvent(deleteParams *DeleteSubscriptionEvent) error
+	ToggleSubscriptionEventDisabled(id string, params *ToggleSubscriptionEventDisabledParams) (*SubscriptionEvent, error)
+	ToggleSubscriptionEventDisabledByExternalID(params *ToggleSubscriptionEventDisabledByExternalIDParams) (*SubscriptionEvent, error)
 }
 
 // API is the handle for communicating with Chartmogul.
 type API struct {
 	ApiKey string
 	Client *http.Client
+	// Retry configures the retry behavior. If nil, defaults to enabled with exponential backoff.
+	// Set Retry.Enabled to false to disable retries entirely.
+	Retry *RetryConfig
 }
 
 // AnchorCursor contains query parameters for anchor based pagination used for some APIs in ChartMogul.

--- a/contacts.go
+++ b/contacts.go
@@ -6,39 +6,39 @@ import "strings"
 type Contact struct {
 	UUID string `json:"uuid,omitempty"`
 	// Basic info
-	CustomerExternalID string                 `json:"customer_external_id,omitempty"`
-	CustomerUUID       string                 `json:"customer_uuid,omitempty"`
-	DataSourceUUID     string                 `json:"data_source_uuid,omitempty"`
-	FirstName          string                 `json:"first_name,omitempty"`
-	LastName           string                 `json:"last_name,omitempty"`
-	LinkedIn           string                 `json:"linked_in,omitempty"`
-	Notes              string                 `json:"notes,omitempty"`
-	Phone              string                 `json:"phone,omitempty"`
-	Position           uint32                 `json:"position,omitempty"`
-	Title              string                 `json:"title,omitempty"`
-	Twitter            string                 `json:"twitter,omitempty"`
+	CustomerExternalID string `json:"customer_external_id,omitempty"`
+	CustomerUUID       string `json:"customer_uuid,omitempty"`
+	DataSourceUUID     string `json:"data_source_uuid,omitempty"`
+	FirstName          string `json:"first_name,omitempty"`
+	LastName           string `json:"last_name,omitempty"`
+	LinkedIn           string `json:"linked_in,omitempty"`
+	Notes              string `json:"notes,omitempty"`
+	Phone              string `json:"phone,omitempty"`
+	Position           uint32 `json:"position,omitempty"`
+	Title              string `json:"title,omitempty"`
+	Twitter            string `json:"twitter,omitempty"`
 	// Using *string allows callers to explicitly clear this field
 	// Passing nil means omit the field; passing "" means clear the field
-	ExternalID         *string                `json:"external_id,omitempty"`
-	Custom             map[string]interface{} `json:"custom,omitempty"`
+	ExternalID *string                `json:"external_id,omitempty"`
+	Custom     map[string]interface{} `json:"custom,omitempty"`
 }
 
 // UpdateContact allows updating contact on the update endpoint.
 type UpdateContact struct {
-	CustomerExternalID string   `json:"customer_external_id,omitempty"`
-	DataSourceUUID     string   `json:"data_source_uuid,omitempty"`
-	FirstName          string   `json:"first_name,omitempty"`
-	LastName           string   `json:"last_name,omitempty"`
-	LinkedIn           string   `json:"linked_in,omitempty"`
-	Notes              string   `json:"notes,omitempty"`
-	Phone              string   `json:"phone,omitempty"`
-	Position           uint32   `json:"position,omitempty"`
-	Title              string   `json:"title,omitempty"`
-	Twitter            string   `json:"twitter,omitempty"`
+	CustomerExternalID string `json:"customer_external_id,omitempty"`
+	DataSourceUUID     string `json:"data_source_uuid,omitempty"`
+	FirstName          string `json:"first_name,omitempty"`
+	LastName           string `json:"last_name,omitempty"`
+	LinkedIn           string `json:"linked_in,omitempty"`
+	Notes              string `json:"notes,omitempty"`
+	Phone              string `json:"phone,omitempty"`
+	Position           uint32 `json:"position,omitempty"`
+	Title              string `json:"title,omitempty"`
+	Twitter            string `json:"twitter,omitempty"`
 	// Using *string allows callers to explicitly clear this field
 	// Passing nil means omit the field; passing "" means clear the field
-	ExternalID         *string  `json:"external_id,omitempty"`
-	Custom             []Custom `json:"custom,omitempty"`
+	ExternalID *string  `json:"external_id,omitempty"`
+	Custom     []Custom `json:"custom,omitempty"`
 }
 
 // NewContact allows creating contact on a new endpoint.
@@ -48,14 +48,14 @@ type NewContact struct {
 	DataSourceUUID string `json:"data_source_uuid,omitempty"`
 
 	// Optional
-	FirstName  string   `json:"first_name,omitempty"`
-	LastName   string   `json:"last_name,omitempty"`
-	LinkedIn   string   `json:"linked_in,omitempty"`
-	Notes      string   `json:"notes,omitempty"`
-	Phone      string   `json:"phone,omitempty"`
-	Position   uint32   `json:"position,omitempty"`
-	Title      string   `json:"title,omitempty"`
-	Twitter    string   `json:"twitter,omitempty"`
+	FirstName string `json:"first_name,omitempty"`
+	LastName  string `json:"last_name,omitempty"`
+	LinkedIn  string `json:"linked_in,omitempty"`
+	Notes     string `json:"notes,omitempty"`
+	Phone     string `json:"phone,omitempty"`
+	Position  uint32 `json:"position,omitempty"`
+	Title     string `json:"title,omitempty"`
+	Twitter   string `json:"twitter,omitempty"`
 	// Using *string allows callers to explicitly clear this field
 	// Passing nil means omit the field; passing "" means clear the field
 	ExternalID *string  `json:"external_id,omitempty"`
@@ -82,28 +82,24 @@ const (
 )
 
 // CreateContact loads the contact to Chartmogul
-//
 func (api API) CreateContact(newContact *NewContact) (*Contact, error) {
 	result := &Contact{}
 	return result, api.create(contactsEndpoint, newContact, result)
 }
 
 // RetrieveContact returns one contact as in API.
-//
 func (api API) RetrieveContact(contactUUID string) (*Contact, error) {
 	result := &Contact{}
 	return result, api.retrieve(singleContactEndpoint, contactUUID, result)
 }
 
 // UpdateContact updates one contact in API.
-//
 func (api API) UpdateContact(input *UpdateContact, contactUUID string) (*Contact, error) {
 	output := &Contact{}
 	return output, api.update(singleContactEndpoint, contactUUID, input, output)
 }
 
 // ListContacts lists all Contacts
-//
 func (api API) ListContacts(listContactsParams *ListContactsParams) (*Contacts, error) {
 	result := &Contacts{}
 	query := make([]interface{}, 0, 1)
@@ -114,7 +110,6 @@ func (api API) ListContacts(listContactsParams *ListContactsParams) (*Contacts, 
 }
 
 // MergeContact merges two contacts.
-//
 func (api API) MergeContacts(intoContactUUID string, fromContactUUID string) (*Contact, error) {
 	result := &Contact{}
 	temp_path := strings.Replace(mergeContactsEndpoint, ":into_contact_uuid", intoContactUUID, 1)
@@ -123,7 +118,6 @@ func (api API) MergeContacts(intoContactUUID string, fromContactUUID string) (*C
 }
 
 // DeleteContact deletes one contact by UUID.
-//
 func (api API) DeleteContact(contactUUID string) error {
 	return api.delete(singleContactEndpoint, contactUUID)
 }

--- a/contacts.go
+++ b/contacts.go
@@ -83,7 +83,6 @@ const (
 
 // CreateContact loads the contact to Chartmogul
 //
-// See https://dev.chartmogul.com/reference/create-a-contact-contacts
 func (api API) CreateContact(newContact *NewContact) (*Contact, error) {
 	result := &Contact{}
 	return result, api.create(contactsEndpoint, newContact, result)
@@ -91,7 +90,6 @@ func (api API) CreateContact(newContact *NewContact) (*Contact, error) {
 
 // RetrieveContact returns one contact as in API.
 //
-// See https://dev.chartmogul.com/reference/retrieve-a-contact
 func (api API) RetrieveContact(contactUUID string) (*Contact, error) {
 	result := &Contact{}
 	return result, api.retrieve(singleContactEndpoint, contactUUID, result)
@@ -99,7 +97,6 @@ func (api API) RetrieveContact(contactUUID string) (*Contact, error) {
 
 // UpdateContact updates one contact in API.
 //
-// See https://dev.chartmogul.com/reference/retrieve-a-contact
 func (api API) UpdateContact(input *UpdateContact, contactUUID string) (*Contact, error) {
 	output := &Contact{}
 	return output, api.update(singleContactEndpoint, contactUUID, input, output)
@@ -107,7 +104,6 @@ func (api API) UpdateContact(input *UpdateContact, contactUUID string) (*Contact
 
 // ListContacts lists all Contacts
 //
-// See https://dev.chartmogul.com/reference/list-all-contacts
 func (api API) ListContacts(listContactsParams *ListContactsParams) (*Contacts, error) {
 	result := &Contacts{}
 	query := make([]interface{}, 0, 1)
@@ -119,7 +115,6 @@ func (api API) ListContacts(listContactsParams *ListContactsParams) (*Contacts, 
 
 // MergeContact merges two contacts.
 //
-// See https://dev.chartmogul.com/reference/merge-contacts
 func (api API) MergeContacts(intoContactUUID string, fromContactUUID string) (*Contact, error) {
 	result := &Contact{}
 	temp_path := strings.Replace(mergeContactsEndpoint, ":into_contact_uuid", intoContactUUID, 1)
@@ -129,7 +124,6 @@ func (api API) MergeContacts(intoContactUUID string, fromContactUUID string) (*C
 
 // DeleteContact deletes one contact by UUID.
 //
-// See https://dev.chartmogul.com/reference/delete-a-contact
 func (api API) DeleteContact(contactUUID string) error {
 	return api.delete(singleContactEndpoint, contactUUID)
 }

--- a/customers.go
+++ b/customers.go
@@ -159,21 +159,18 @@ const (
 )
 
 // CreateCustomer loads the customer to Chartmogul. New endpoint - with attributes.
-//
 func (api API) CreateCustomer(newCustomer *NewCustomer) (*Customer, error) {
 	result := &Customer{}
 	return result, api.create(customersEndpoint, newCustomer, result)
 }
 
 // RetrieveCustomer returns one customer as in API.
-//
 func (api API) RetrieveCustomer(customerUUID string) (*Customer, error) {
 	result := &Customer{}
 	return result, api.retrieve(singleCustomerEndpoint, customerUUID, result)
 }
 
 // UpdateCustomer updates one customer in API.
-//
 func (api API) UpdateCustomer(customer *Customer, customerUUID string) (*Customer, error) {
 	result := &Customer{}
 	return result, api.update(singleCustomerEndpoint,
@@ -183,14 +180,12 @@ func (api API) UpdateCustomer(customer *Customer, customerUUID string) (*Custome
 }
 
 // UpdateCustomerV2 updates one customer in API.
-//
 func (api API) UpdateCustomerV2(input *UpdateCustomer, customerUUID string) (*Customer, error) {
 	output := &Customer{}
 	return output, api.update(singleCustomerEndpoint, customerUUID, input, output)
 }
 
 // ListCustomers lists all Customers for cutomer of given UUID.
-//
 func (api API) ListCustomers(listCustomersParams *ListCustomersParams) (*Customers, error) {
 	result := &Customers{}
 	query := make([]interface{}, 0, 1)
@@ -201,39 +196,33 @@ func (api API) ListCustomers(listCustomersParams *ListCustomersParams) (*Custome
 }
 
 // SearchCustomers lists all Customers for cutomer of given UUID.
-//
 func (api API) SearchCustomers(searchCustomersParams *SearchCustomersParams) (*Customers, error) {
 	result := &Customers{}
 	return result, api.list(searchCustomersEndpoint, result, *searchCustomersParams)
 }
 
 // MergeCustomers merges two cutomers.
-//
 func (api API) MergeCustomers(mergeCustomersParams *MergeCustomersParams) error {
 	return api.merge(mergeCustomersEndpoint, *mergeCustomersParams)
 }
 
 // UnmergeCustomers unmerges two cutomers.
-//
 func (api API) UnmergeCustomers(unmergeCustomersParams *UnmergeCustomersParams) error {
 	return api.unmerge(unmergeCustomersEndpoint, *unmergeCustomersParams)
 }
 
 // DeleteCustomer deletes one customer by UUID.
-//
 func (api API) DeleteCustomer(customerUUID string) error {
 	return api.delete(singleCustomerEndpoint, customerUUID)
 }
 
 // DeleteCustomerInvoices deletes all customer's invoices by UUID for given data source UUID.
-//
 func (api API) DeleteCustomerInvoices(dataSourceUUID, customerUUID string) error {
 	path := strings.Replace(deleteCustomerInvoicesEndpoint, ":data_source_uuid", dataSourceUUID, 1)
 	return api.delete(path, customerUUID)
 }
 
 // DeleteCustomerInvoicesV2 deletes all customer's invoices by UUID & ExternalID for given data source UUID.
-//
 func (api API) DeleteCustomerInvoicesV2(dataSourceUUID, customerUUID string, deleteCustomerInvoicesParams *DeleteCustomerInvoicesParams) error {
 	path := strings.Replace(deleteCustomerInvoicesEndpoint, ":data_source_uuid", dataSourceUUID, 1)
 
@@ -245,7 +234,6 @@ func (api API) DeleteCustomerInvoicesV2(dataSourceUUID, customerUUID string, del
 }
 
 // ListCustomersContacts
-//
 func (api API) ListCustomersContacts(listContactsParams *ListContactsParams, customerUUID string) (*Contacts, error) {
 	result := &Contacts{}
 	query := make([]interface{}, 0, 1)
@@ -257,7 +245,6 @@ func (api API) ListCustomersContacts(listContactsParams *ListContactsParams, cus
 }
 
 // CreateCustomersContacts
-//
 func (api API) CreateCustomersContact(newContact *NewContact, customerUUID string) (*Contact, error) {
 	result := &Contact{}
 	path := strings.Replace(customerContactsEndpoint, ":uuid", customerUUID, 1)
@@ -265,7 +252,6 @@ func (api API) CreateCustomersContact(newContact *NewContact, customerUUID strin
 }
 
 // ListCustomerNotes
-//
 func (api API) ListCustomerNotes(listCustomerNotesParams *ListNotesParams, customerUUID string) (*Notes, error) {
 	result := &Notes{}
 	query := make([]interface{}, 0, 1)
@@ -279,7 +265,6 @@ func (api API) ListCustomerNotes(listCustomerNotesParams *ListNotesParams, custo
 }
 
 // CreateCustomerNote
-//
 func (api API) CreateCustomerNote(input *NewNote, customerUUID string) (*Note, error) {
 	result := &Note{}
 	if input.CustomerUUID == "" {
@@ -289,7 +274,6 @@ func (api API) CreateCustomerNote(input *NewNote, customerUUID string) (*Note, e
 }
 
 // ListCustomerOpporunities
-//
 func (api API) ListCustomerOpporunities(listOpportunitiesParams *ListOpportunitiesParams, customerUUID string) (*Opportunities, error) {
 	result := &Opportunities{}
 	query := make([]interface{}, 0, 1)
@@ -303,7 +287,6 @@ func (api API) ListCustomerOpporunities(listOpportunitiesParams *ListOpportuniti
 }
 
 // CreateCustomerOpportunity
-//
 func (api API) CreateCustomerOpportunity(input *NewOpportunity, customerUUID string) (*Opportunity, error) {
 	result := &Opportunity{}
 	if input.CustomerUUID == "" {
@@ -313,7 +296,6 @@ func (api API) CreateCustomerOpportunity(input *NewOpportunity, customerUUID str
 }
 
 // ListCustomerTasks
-//
 func (api API) ListCustomerTasks(listTasksParams *ListTasksParams, customerUUID string) (*Tasks, error) {
 	result := &Tasks{}
 	query := make([]interface{}, 0, 1)
@@ -327,7 +309,6 @@ func (api API) ListCustomerTasks(listTasksParams *ListTasksParams, customerUUID 
 }
 
 // CreateCustomerTask
-//
 func (api API) CreateCustomerTask(input *NewTask, customerUUID string) (*Task, error) {
 	result := &Task{}
 	if input.CustomerUUID == "" {

--- a/customers.go
+++ b/customers.go
@@ -160,7 +160,6 @@ const (
 
 // CreateCustomer loads the customer to Chartmogul. New endpoint - with attributes.
 //
-// See https://dev.chartmogul.com/reference/customers
 func (api API) CreateCustomer(newCustomer *NewCustomer) (*Customer, error) {
 	result := &Customer{}
 	return result, api.create(customersEndpoint, newCustomer, result)
@@ -168,7 +167,6 @@ func (api API) CreateCustomer(newCustomer *NewCustomer) (*Customer, error) {
 
 // RetrieveCustomer returns one customer as in API.
 //
-// See https://dev.chartmogul.com/reference/customers
 func (api API) RetrieveCustomer(customerUUID string) (*Customer, error) {
 	result := &Customer{}
 	return result, api.retrieve(singleCustomerEndpoint, customerUUID, result)
@@ -176,7 +174,6 @@ func (api API) RetrieveCustomer(customerUUID string) (*Customer, error) {
 
 // UpdateCustomer updates one customer in API.
 //
-// See https://dev.chartmogul.com/reference/customers
 func (api API) UpdateCustomer(customer *Customer, customerUUID string) (*Customer, error) {
 	result := &Customer{}
 	return result, api.update(singleCustomerEndpoint,
@@ -187,7 +184,6 @@ func (api API) UpdateCustomer(customer *Customer, customerUUID string) (*Custome
 
 // UpdateCustomerV2 updates one customer in API.
 //
-// See https://dev.chartmogul.com/reference/update-a-customer
 func (api API) UpdateCustomerV2(input *UpdateCustomer, customerUUID string) (*Customer, error) {
 	output := &Customer{}
 	return output, api.update(singleCustomerEndpoint, customerUUID, input, output)
@@ -195,7 +191,6 @@ func (api API) UpdateCustomerV2(input *UpdateCustomer, customerUUID string) (*Cu
 
 // ListCustomers lists all Customers for cutomer of given UUID.
 //
-// See https://dev.chartmogul.com/reference/customers
 func (api API) ListCustomers(listCustomersParams *ListCustomersParams) (*Customers, error) {
 	result := &Customers{}
 	query := make([]interface{}, 0, 1)
@@ -207,7 +202,6 @@ func (api API) ListCustomers(listCustomersParams *ListCustomersParams) (*Custome
 
 // SearchCustomers lists all Customers for cutomer of given UUID.
 //
-// See https://dev.chartmogul.com/reference/customers
 func (api API) SearchCustomers(searchCustomersParams *SearchCustomersParams) (*Customers, error) {
 	result := &Customers{}
 	return result, api.list(searchCustomersEndpoint, result, *searchCustomersParams)
@@ -215,28 +209,24 @@ func (api API) SearchCustomers(searchCustomersParams *SearchCustomersParams) (*C
 
 // MergeCustomers merges two cutomers.
 //
-// See https://dev.chartmogul.com/reference/customers
 func (api API) MergeCustomers(mergeCustomersParams *MergeCustomersParams) error {
 	return api.merge(mergeCustomersEndpoint, *mergeCustomersParams)
 }
 
 // UnmergeCustomers unmerges two cutomers.
 //
-// See https://dev.chartmogul.com/reference/customers
 func (api API) UnmergeCustomers(unmergeCustomersParams *UnmergeCustomersParams) error {
 	return api.unmerge(unmergeCustomersEndpoint, *unmergeCustomersParams)
 }
 
 // DeleteCustomer deletes one customer by UUID.
 //
-// See https://dev.chartmogul.com/reference/customers
 func (api API) DeleteCustomer(customerUUID string) error {
 	return api.delete(singleCustomerEndpoint, customerUUID)
 }
 
 // DeleteCustomerInvoices deletes all customer's invoices by UUID for given data source UUID.
 //
-// See https://dev.chartmogul.com/reference/customers
 func (api API) DeleteCustomerInvoices(dataSourceUUID, customerUUID string) error {
 	path := strings.Replace(deleteCustomerInvoicesEndpoint, ":data_source_uuid", dataSourceUUID, 1)
 	return api.delete(path, customerUUID)
@@ -244,7 +234,6 @@ func (api API) DeleteCustomerInvoices(dataSourceUUID, customerUUID string) error
 
 // DeleteCustomerInvoicesV2 deletes all customer's invoices by UUID & ExternalID for given data source UUID.
 //
-// See https://dev.chartmogul.com/reference/customers
 func (api API) DeleteCustomerInvoicesV2(dataSourceUUID, customerUUID string, deleteCustomerInvoicesParams *DeleteCustomerInvoicesParams) error {
 	path := strings.Replace(deleteCustomerInvoicesEndpoint, ":data_source_uuid", dataSourceUUID, 1)
 
@@ -257,7 +246,6 @@ func (api API) DeleteCustomerInvoicesV2(dataSourceUUID, customerUUID string, del
 
 // ListCustomersContacts
 //
-// See https://dev.chartmogul.com/reference/list-customers-contacts
 func (api API) ListCustomersContacts(listContactsParams *ListContactsParams, customerUUID string) (*Contacts, error) {
 	result := &Contacts{}
 	query := make([]interface{}, 0, 1)
@@ -270,7 +258,6 @@ func (api API) ListCustomersContacts(listContactsParams *ListContactsParams, cus
 
 // CreateCustomersContacts
 //
-// See https://dev.chartmogul.com/reference/create-a-contact
 func (api API) CreateCustomersContact(newContact *NewContact, customerUUID string) (*Contact, error) {
 	result := &Contact{}
 	path := strings.Replace(customerContactsEndpoint, ":uuid", customerUUID, 1)
@@ -279,7 +266,6 @@ func (api API) CreateCustomersContact(newContact *NewContact, customerUUID strin
 
 // ListCustomerNotes
 //
-// See https://dev.chartmogul.com/reference/list-customer-notes
 func (api API) ListCustomerNotes(listCustomerNotesParams *ListNotesParams, customerUUID string) (*Notes, error) {
 	result := &Notes{}
 	query := make([]interface{}, 0, 1)
@@ -294,7 +280,6 @@ func (api API) ListCustomerNotes(listCustomerNotesParams *ListNotesParams, custo
 
 // CreateCustomerNote
 //
-// See https://dev.chartmogul.com/reference/create-a-customer-note
 func (api API) CreateCustomerNote(input *NewNote, customerUUID string) (*Note, error) {
 	result := &Note{}
 	if input.CustomerUUID == "" {
@@ -305,7 +290,6 @@ func (api API) CreateCustomerNote(input *NewNote, customerUUID string) (*Note, e
 
 // ListCustomerOpporunities
 //
-// See https://dev.chartmogul.com/reference/list-opportunities
 func (api API) ListCustomerOpporunities(listOpportunitiesParams *ListOpportunitiesParams, customerUUID string) (*Opportunities, error) {
 	result := &Opportunities{}
 	query := make([]interface{}, 0, 1)
@@ -320,7 +304,6 @@ func (api API) ListCustomerOpporunities(listOpportunitiesParams *ListOpportuniti
 
 // CreateCustomerOpportunity
 //
-// See https://dev.chartmogul.com/reference/create-an-opportunity
 func (api API) CreateCustomerOpportunity(input *NewOpportunity, customerUUID string) (*Opportunity, error) {
 	result := &Opportunity{}
 	if input.CustomerUUID == "" {
@@ -331,7 +314,6 @@ func (api API) CreateCustomerOpportunity(input *NewOpportunity, customerUUID str
 
 // ListCustomerTasks
 //
-// See https://dev.chartmogul.com/reference/tasks/list/
 func (api API) ListCustomerTasks(listTasksParams *ListTasksParams, customerUUID string) (*Tasks, error) {
 	result := &Tasks{}
 	query := make([]interface{}, 0, 1)
@@ -346,7 +328,6 @@ func (api API) ListCustomerTasks(listTasksParams *ListTasksParams, customerUUID 
 
 // CreateCustomerTask
 //
-// See https://dev.chartmogul.com/reference/tasks/add/
 func (api API) CreateCustomerTask(input *NewTask, customerUUID string) (*Task, error) {
 	result := &Task{}
 	if input.CustomerUUID == "" {

--- a/customers.go
+++ b/customers.go
@@ -160,7 +160,7 @@ const (
 
 // CreateCustomer loads the customer to Chartmogul. New endpoint - with attributes.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customers
+// See https://dev.chartmogul.com/reference/customers
 func (api API) CreateCustomer(newCustomer *NewCustomer) (*Customer, error) {
 	result := &Customer{}
 	return result, api.create(customersEndpoint, newCustomer, result)
@@ -168,7 +168,7 @@ func (api API) CreateCustomer(newCustomer *NewCustomer) (*Customer, error) {
 
 // RetrieveCustomer returns one customer as in API.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customers
+// See https://dev.chartmogul.com/reference/customers
 func (api API) RetrieveCustomer(customerUUID string) (*Customer, error) {
 	result := &Customer{}
 	return result, api.retrieve(singleCustomerEndpoint, customerUUID, result)
@@ -176,7 +176,7 @@ func (api API) RetrieveCustomer(customerUUID string) (*Customer, error) {
 
 // UpdateCustomer updates one customer in API.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customers
+// See https://dev.chartmogul.com/reference/customers
 func (api API) UpdateCustomer(customer *Customer, customerUUID string) (*Customer, error) {
 	result := &Customer{}
 	return result, api.update(singleCustomerEndpoint,
@@ -187,7 +187,7 @@ func (api API) UpdateCustomer(customer *Customer, customerUUID string) (*Custome
 
 // UpdateCustomerV2 updates one customer in API.
 //
-// See https://dev.chartmogul.com/v1.0/reference#update-a-customer
+// See https://dev.chartmogul.com/reference/update-a-customer
 func (api API) UpdateCustomerV2(input *UpdateCustomer, customerUUID string) (*Customer, error) {
 	output := &Customer{}
 	return output, api.update(singleCustomerEndpoint, customerUUID, input, output)
@@ -195,7 +195,7 @@ func (api API) UpdateCustomerV2(input *UpdateCustomer, customerUUID string) (*Cu
 
 // ListCustomers lists all Customers for cutomer of given UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customers
+// See https://dev.chartmogul.com/reference/customers
 func (api API) ListCustomers(listCustomersParams *ListCustomersParams) (*Customers, error) {
 	result := &Customers{}
 	query := make([]interface{}, 0, 1)
@@ -207,7 +207,7 @@ func (api API) ListCustomers(listCustomersParams *ListCustomersParams) (*Custome
 
 // SearchCustomers lists all Customers for cutomer of given UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customers
+// See https://dev.chartmogul.com/reference/customers
 func (api API) SearchCustomers(searchCustomersParams *SearchCustomersParams) (*Customers, error) {
 	result := &Customers{}
 	return result, api.list(searchCustomersEndpoint, result, *searchCustomersParams)
@@ -215,28 +215,28 @@ func (api API) SearchCustomers(searchCustomersParams *SearchCustomersParams) (*C
 
 // MergeCustomers merges two cutomers.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customers
+// See https://dev.chartmogul.com/reference/customers
 func (api API) MergeCustomers(mergeCustomersParams *MergeCustomersParams) error {
 	return api.merge(mergeCustomersEndpoint, *mergeCustomersParams)
 }
 
 // UnmergeCustomers unmerges two cutomers.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customers
+// See https://dev.chartmogul.com/reference/customers
 func (api API) UnmergeCustomers(unmergeCustomersParams *UnmergeCustomersParams) error {
 	return api.unmerge(unmergeCustomersEndpoint, *unmergeCustomersParams)
 }
 
 // DeleteCustomer deletes one customer by UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customers
+// See https://dev.chartmogul.com/reference/customers
 func (api API) DeleteCustomer(customerUUID string) error {
 	return api.delete(singleCustomerEndpoint, customerUUID)
 }
 
 // DeleteCustomerInvoices deletes all customer's invoices by UUID for given data source UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customers
+// See https://dev.chartmogul.com/reference/customers
 func (api API) DeleteCustomerInvoices(dataSourceUUID, customerUUID string) error {
 	path := strings.Replace(deleteCustomerInvoicesEndpoint, ":data_source_uuid", dataSourceUUID, 1)
 	return api.delete(path, customerUUID)
@@ -244,7 +244,7 @@ func (api API) DeleteCustomerInvoices(dataSourceUUID, customerUUID string) error
 
 // DeleteCustomerInvoicesV2 deletes all customer's invoices by UUID & ExternalID for given data source UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#customers
+// See https://dev.chartmogul.com/reference/customers
 func (api API) DeleteCustomerInvoicesV2(dataSourceUUID, customerUUID string, deleteCustomerInvoicesParams *DeleteCustomerInvoicesParams) error {
 	path := strings.Replace(deleteCustomerInvoicesEndpoint, ":data_source_uuid", dataSourceUUID, 1)
 

--- a/datasources.go
+++ b/datasources.go
@@ -14,7 +14,6 @@ type AutoChurnSubscriptionSetting struct {
 }
 
 // DataSource represents API data source in ChartMogul.
-// See https://dev.chartmogul.com/reference/list-data-sources
 type DataSource struct {
 	UUID                         string                        `json:"uuid"`
 	Name                         string                        `json:"name"`
@@ -60,7 +59,6 @@ const (
 
 // CreateDataSource creates an API Data Source in ChartMogul.
 //
-// See https://dev.chartmogul.com/reference/data-sources
 func (api API) CreateDataSource(name string) (*DataSource, error) {
 	ds := &DataSource{}
 	err := api.create(dataSourcesEndpoint, createDataSourceCall{Name: name}, ds)
@@ -70,7 +68,6 @@ func (api API) CreateDataSource(name string) (*DataSource, error) {
 // CreateDataSourceWithSystem creates an API Data Source in ChartMogul.
 // * Allows other parameters than just the name.
 //
-// See https://dev.chartmogul.com/reference/data-sources
 func (api API) CreateDataSourceWithSystem(dataSource *DataSource) (*DataSource, error) {
 	ds := &DataSource{}
 	err := api.create(dataSourcesEndpoint, dataSource, ds)
@@ -83,7 +80,6 @@ func (api API) CreateDataSourceWithSystem(dataSource *DataSource) (*DataSource, 
 // - WithAutoChurnSubscriptionSetting: include auto-churn subscription settings
 // - WithInvoiceHandlingSetting: include invoice handling settings
 //
-// See https://dev.chartmogul.com/reference/data-sources
 func (api API) RetrieveDataSource(dataSourceUUID string, params ...*ExtraDataSourceParams) (*DataSource, error) {
 	result := &DataSource{}
 
@@ -101,7 +97,6 @@ func (api API) RetrieveDataSource(dataSourceUUID string, params ...*ExtraDataSou
 // - WithAutoChurnSubscriptionSetting: include auto-churn subscription settings
 // - WithInvoiceHandlingSetting: include invoice handling settings
 //
-// See https://dev.chartmogul.com/reference/data-sources
 func (api API) ListDataSources(params ...*ExtraDataSourceParams) (*DataSources, error) {
 	ds := &DataSources{}
 	if len(params) == 0 || params[0] == nil {
@@ -120,7 +115,6 @@ func (api API) ListDataSources(params ...*ExtraDataSourceParams) (*DataSources, 
 // ListDataSourcesWithFilters lists all available Data Sources (no paging).
 // Accepts filtering parameters and extra data parameters in a single struct.
 //
-// See https://dev.chartmogul.com/reference/data-sources
 func (api API) ListDataSourcesWithFilters(listDataSourcesParams *ListDataSourcesParams) (*DataSources, error) {
 	ds := &DataSources{}
 	query := make([]interface{}, 0, 1)
@@ -133,14 +127,12 @@ func (api API) ListDataSourcesWithFilters(listDataSourcesParams *ListDataSources
 
 // DeleteDataSource deletes the data source identified by its UUID.
 //
-// See https://dev.chartmogul.com/reference/data-sources
 func (api API) DeleteDataSource(uuid string) error {
 	return api.delete(singleDataSourceEndpoint, uuid)
 }
 
 // PurgeDataSource deletes all the data except the data source itself and the customers
 //
-// See https://dev.chartmogul.com/reference/data-sources
 func (api API) PurgeDataSource(dataSourceUUID string) error {
 	return api.delete(purgeDataSourceEndpoint, dataSourceUUID)
 }

--- a/datasources.go
+++ b/datasources.go
@@ -14,7 +14,7 @@ type AutoChurnSubscriptionSetting struct {
 }
 
 // DataSource represents API data source in ChartMogul.
-// See https://dev.chartmogul.com/v1.0/reference#list-data-sources
+// See https://dev.chartmogul.com/reference/list-data-sources
 type DataSource struct {
 	UUID                         string                        `json:"uuid"`
 	Name                         string                        `json:"name"`
@@ -60,7 +60,7 @@ const (
 
 // CreateDataSource creates an API Data Source in ChartMogul.
 //
-// See https://dev.chartmogul.com/v1.0/reference#data-sources
+// See https://dev.chartmogul.com/reference/data-sources
 func (api API) CreateDataSource(name string) (*DataSource, error) {
 	ds := &DataSource{}
 	err := api.create(dataSourcesEndpoint, createDataSourceCall{Name: name}, ds)
@@ -70,7 +70,7 @@ func (api API) CreateDataSource(name string) (*DataSource, error) {
 // CreateDataSourceWithSystem creates an API Data Source in ChartMogul.
 // * Allows other parameters than just the name.
 //
-// See https://dev.chartmogul.com/v1.0/reference#data-sources
+// See https://dev.chartmogul.com/reference/data-sources
 func (api API) CreateDataSourceWithSystem(dataSource *DataSource) (*DataSource, error) {
 	ds := &DataSource{}
 	err := api.create(dataSourcesEndpoint, dataSource, ds)
@@ -83,7 +83,7 @@ func (api API) CreateDataSourceWithSystem(dataSource *DataSource) (*DataSource, 
 // - WithAutoChurnSubscriptionSetting: include auto-churn subscription settings
 // - WithInvoiceHandlingSetting: include invoice handling settings
 //
-// See https://dev.chartmogul.com/v1.0/reference#data-sources
+// See https://dev.chartmogul.com/reference/data-sources
 func (api API) RetrieveDataSource(dataSourceUUID string, params ...*ExtraDataSourceParams) (*DataSource, error) {
 	result := &DataSource{}
 
@@ -101,7 +101,7 @@ func (api API) RetrieveDataSource(dataSourceUUID string, params ...*ExtraDataSou
 // - WithAutoChurnSubscriptionSetting: include auto-churn subscription settings
 // - WithInvoiceHandlingSetting: include invoice handling settings
 //
-// See https://dev.chartmogul.com/v1.0/reference#data-sources
+// See https://dev.chartmogul.com/reference/data-sources
 func (api API) ListDataSources(params ...*ExtraDataSourceParams) (*DataSources, error) {
 	ds := &DataSources{}
 	if len(params) == 0 || params[0] == nil {
@@ -120,7 +120,7 @@ func (api API) ListDataSources(params ...*ExtraDataSourceParams) (*DataSources, 
 // ListDataSourcesWithFilters lists all available Data Sources (no paging).
 // Accepts filtering parameters and extra data parameters in a single struct.
 //
-// See https://dev.chartmogul.com/v1.0/reference#data-sources
+// See https://dev.chartmogul.com/reference/data-sources
 func (api API) ListDataSourcesWithFilters(listDataSourcesParams *ListDataSourcesParams) (*DataSources, error) {
 	ds := &DataSources{}
 	query := make([]interface{}, 0, 1)
@@ -133,14 +133,14 @@ func (api API) ListDataSourcesWithFilters(listDataSourcesParams *ListDataSources
 
 // DeleteDataSource deletes the data source identified by its UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#data-sources
+// See https://dev.chartmogul.com/reference/data-sources
 func (api API) DeleteDataSource(uuid string) error {
 	return api.delete(singleDataSourceEndpoint, uuid)
 }
 
 // PurgeDataSource deletes all the data except the data source itself and the customers
 //
-// See https://dev.chartmogul.com/v1.0/reference#data-sources
+// See https://dev.chartmogul.com/reference/data-sources
 func (api API) PurgeDataSource(dataSourceUUID string) error {
 	return api.delete(purgeDataSourceEndpoint, dataSourceUUID)
 }

--- a/datasources.go
+++ b/datasources.go
@@ -58,7 +58,6 @@ const (
 )
 
 // CreateDataSource creates an API Data Source in ChartMogul.
-//
 func (api API) CreateDataSource(name string) (*DataSource, error) {
 	ds := &DataSource{}
 	err := api.create(dataSourcesEndpoint, createDataSourceCall{Name: name}, ds)
@@ -67,7 +66,6 @@ func (api API) CreateDataSource(name string) (*DataSource, error) {
 
 // CreateDataSourceWithSystem creates an API Data Source in ChartMogul.
 // * Allows other parameters than just the name.
-//
 func (api API) CreateDataSourceWithSystem(dataSource *DataSource) (*DataSource, error) {
 	ds := &DataSource{}
 	err := api.create(dataSourcesEndpoint, dataSource, ds)
@@ -79,7 +77,6 @@ func (api API) CreateDataSourceWithSystem(dataSource *DataSource) (*DataSource, 
 // - WithProcessingStatus: include processing status information
 // - WithAutoChurnSubscriptionSetting: include auto-churn subscription settings
 // - WithInvoiceHandlingSetting: include invoice handling settings
-//
 func (api API) RetrieveDataSource(dataSourceUUID string, params ...*ExtraDataSourceParams) (*DataSource, error) {
 	result := &DataSource{}
 
@@ -96,7 +93,6 @@ func (api API) RetrieveDataSource(dataSourceUUID string, params ...*ExtraDataSou
 // - WithProcessingStatus: include processing status information
 // - WithAutoChurnSubscriptionSetting: include auto-churn subscription settings
 // - WithInvoiceHandlingSetting: include invoice handling settings
-//
 func (api API) ListDataSources(params ...*ExtraDataSourceParams) (*DataSources, error) {
 	ds := &DataSources{}
 	if len(params) == 0 || params[0] == nil {
@@ -114,7 +110,6 @@ func (api API) ListDataSources(params ...*ExtraDataSourceParams) (*DataSources, 
 
 // ListDataSourcesWithFilters lists all available Data Sources (no paging).
 // Accepts filtering parameters and extra data parameters in a single struct.
-//
 func (api API) ListDataSourcesWithFilters(listDataSourcesParams *ListDataSourcesParams) (*DataSources, error) {
 	ds := &DataSources{}
 	query := make([]interface{}, 0, 1)
@@ -126,13 +121,11 @@ func (api API) ListDataSourcesWithFilters(listDataSourcesParams *ListDataSources
 }
 
 // DeleteDataSource deletes the data source identified by its UUID.
-//
 func (api API) DeleteDataSource(uuid string) error {
 	return api.delete(singleDataSourceEndpoint, uuid)
 }
 
 // PurgeDataSource deletes all the data except the data source itself and the customers
-//
 func (api API) PurgeDataSource(dataSourceUUID string) error {
 	return api.delete(purgeDataSourceEndpoint, dataSourceUUID)
 }

--- a/generic.go
+++ b/generic.go
@@ -58,7 +58,6 @@ func (api API) create(path string, input interface{}, output interface{}) error 
 	var errs []error
 
 	// Retry on HTTP 429 rate limit, or network error, see:
-	// https://dev.chartmogul.com/docs/rate-limits
 	// https://godoc.org/github.com/cenkalti/backoff#pkg-constants
 	// nolint:errcheck
 	backoff.Retry(func() error {

--- a/generic.go
+++ b/generic.go
@@ -19,10 +19,7 @@ var errRetry = errors.New("Retrying")
 
 // RetryConfig allows configuring the retry behavior for API requests.
 type RetryConfig struct {
-<<<<<<< HEAD
 	// Enabled controls whether retries are enabled. Defaults to true.
-	Enabled bool
-	// Defaults to true.
 	Enabled bool
 	// Maximum total time for retries. Defaults to backoff's default (15 minutes).
 	MaxElapsedTime time.Duration

--- a/generic.go
+++ b/generic.go
@@ -3,6 +3,7 @@ package chartmogul
 import (
 	"errors"
 	"strings"
+	"time"
 
 	backoff "github.com/cenkalti/backoff/v3"
 	"github.com/parnurzeal/gorequest"
@@ -15,6 +16,40 @@ import (
 
 // static internal error helper
 var errRetry = errors.New("Retrying")
+
+// RetryConfig allows configuring the retry behavior for API requests.
+type RetryConfig struct {
+	// Enabled controls whether retries are enabled. Defaults to true.
+	Enabled bool
+	// MaxElapsedTime is the maximum total time for retries. Defaults to backoff's default (15 minutes).
+	MaxElapsedTime time.Duration
+	// MaxInterval is the maximum interval between retries. Defaults to backoff's default (60 seconds).
+	MaxInterval time.Duration
+}
+
+// defaultRetryConfig returns the default retry configuration (enabled, using backoff defaults).
+func defaultRetryConfig() *RetryConfig {
+	return &RetryConfig{Enabled: true}
+}
+
+// newBackoff creates a backoff strategy based on the API's retry config.
+func (api API) newBackoff() backoff.BackOff {
+	cfg := api.Retry
+	if cfg == nil {
+		cfg = defaultRetryConfig()
+	}
+	if !cfg.Enabled {
+		return &backoff.StopBackOff{}
+	}
+	b := backoff.NewExponentialBackOff()
+	if cfg.MaxElapsedTime > 0 {
+		b.MaxElapsedTime = cfg.MaxElapsedTime
+	}
+	if cfg.MaxInterval > 0 {
+		b.MaxInterval = cfg.MaxInterval
+	}
+	return b
+}
 
 // CREATE
 func (api API) create(path string, input interface{}, output interface{}) error {
@@ -36,7 +71,7 @@ func (api API) create(path string, input interface{}, output interface{}) error 
 			return errRetry
 		}
 		return nil
-	}, backoff.NewExponentialBackOff())
+	}, api.newBackoff())
 
 	// wrapping []errors into compatible error & making HTTPError
 	return wrapErrors(res, body, errs)
@@ -60,7 +95,7 @@ func (api API) list(path string, output interface{}, query ...interface{}) error
 			return errRetry
 		}
 		return nil
-	}, backoff.NewExponentialBackOff())
+	}, api.newBackoff())
 
 	return wrapErrors(res, body, errs)
 }
@@ -83,7 +118,7 @@ func (api API) retrieve(path string, uuid string, output interface{}) error {
 			return errRetry
 		}
 		return nil
-	}, backoff.NewExponentialBackOff())
+	}, api.newBackoff())
 
 	return wrapErrors(res, body, errs)
 }
@@ -109,7 +144,7 @@ func (api API) retrieveWithParams(path string, uuid string, output interface{}, 
 			return errRetry
 		}
 		return nil
-	}, backoff.NewExponentialBackOff())
+	}, api.newBackoff())
 
 	return wrapErrors(res, body, errs)
 }
@@ -131,7 +166,7 @@ func (api API) merge(path string, input interface{}) error {
 			return errRetry
 		}
 		return nil
-	}, backoff.NewExponentialBackOff())
+	}, api.newBackoff())
 
 	return wrapErrors(res, []byte(body), errs)
 }
@@ -169,7 +204,7 @@ func (api API) updateImpl(path string, uuid string, input interface{}, output in
 			return errRetry
 		}
 		return nil
-	}, backoff.NewExponentialBackOff())
+	}, api.newBackoff())
 
 	return wrapErrors(res, body, errs)
 }
@@ -204,7 +239,7 @@ func (api API) delete(path string, uuid string) error {
 			return errRetry
 		}
 		return nil
-	}, backoff.NewExponentialBackOff())
+	}, api.newBackoff())
 
 	return wrapErrors(res, []byte(body), errs)
 }
@@ -225,7 +260,7 @@ func (api API) deleteWhat(path string, uuid string, input interface{}, output in
 			return errRetry
 		}
 		return nil
-	}, backoff.NewExponentialBackOff())
+	}, api.newBackoff())
 
 	return wrapErrors(res, body, errs)
 }
@@ -245,7 +280,7 @@ func (api API) deleteWithData(path string, input interface{}) error {
 			return errRetry
 		}
 		return nil
-	}, backoff.NewExponentialBackOff())
+	}, api.newBackoff())
 
 	// wrapping []errors into compatible error & making HTTPError
 	return wrapErrors(res, []byte(body), errs)

--- a/generic.go
+++ b/generic.go
@@ -19,11 +19,14 @@ var errRetry = errors.New("Retrying")
 
 // RetryConfig allows configuring the retry behavior for API requests.
 type RetryConfig struct {
+<<<<<<< HEAD
 	// Enabled controls whether retries are enabled. Defaults to true.
 	Enabled bool
-	// MaxElapsedTime is the maximum total time for retries. Defaults to backoff's default (15 minutes).
+	// Defaults to true.
+	Enabled bool
+	// Maximum total time for retries. Defaults to backoff's default (15 minutes).
 	MaxElapsedTime time.Duration
-	// MaxInterval is the maximum interval between retries. Defaults to backoff's default (60 seconds).
+	// Maximum interval between retries. Defaults to backoff's default (60 seconds).
 	MaxInterval time.Duration
 }
 
@@ -32,8 +35,8 @@ func defaultRetryConfig() *RetryConfig {
 	return &RetryConfig{Enabled: true}
 }
 
-// newBackoff creates a backoff strategy based on the API's retry config.
-func (api API) newBackoff() backoff.BackOff {
+// backoffStrategy creates a backoff strategy based on the API's retry config.
+func (api API) backoffStrategy() backoff.BackOff {
 	cfg := api.Retry
 	if cfg == nil {
 		cfg = defaultRetryConfig()
@@ -70,7 +73,7 @@ func (api API) create(path string, input interface{}, output interface{}) error 
 			return errRetry
 		}
 		return nil
-	}, api.newBackoff())
+	}, api.backoffStrategy())
 
 	// wrapping []errors into compatible error & making HTTPError
 	return wrapErrors(res, body, errs)
@@ -94,7 +97,7 @@ func (api API) list(path string, output interface{}, query ...interface{}) error
 			return errRetry
 		}
 		return nil
-	}, api.newBackoff())
+	}, api.backoffStrategy())
 
 	return wrapErrors(res, body, errs)
 }
@@ -117,7 +120,7 @@ func (api API) retrieve(path string, uuid string, output interface{}) error {
 			return errRetry
 		}
 		return nil
-	}, api.newBackoff())
+	}, api.backoffStrategy())
 
 	return wrapErrors(res, body, errs)
 }
@@ -143,7 +146,7 @@ func (api API) retrieveWithParams(path string, uuid string, output interface{}, 
 			return errRetry
 		}
 		return nil
-	}, api.newBackoff())
+	}, api.backoffStrategy())
 
 	return wrapErrors(res, body, errs)
 }
@@ -165,7 +168,7 @@ func (api API) merge(path string, input interface{}) error {
 			return errRetry
 		}
 		return nil
-	}, api.newBackoff())
+	}, api.backoffStrategy())
 
 	return wrapErrors(res, []byte(body), errs)
 }
@@ -203,7 +206,7 @@ func (api API) updateImpl(path string, uuid string, input interface{}, output in
 			return errRetry
 		}
 		return nil
-	}, api.newBackoff())
+	}, api.backoffStrategy())
 
 	return wrapErrors(res, body, errs)
 }
@@ -238,7 +241,7 @@ func (api API) delete(path string, uuid string) error {
 			return errRetry
 		}
 		return nil
-	}, api.newBackoff())
+	}, api.backoffStrategy())
 
 	return wrapErrors(res, []byte(body), errs)
 }
@@ -259,7 +262,7 @@ func (api API) deleteWhat(path string, uuid string, input interface{}, output in
 			return errRetry
 		}
 		return nil
-	}, api.newBackoff())
+	}, api.backoffStrategy())
 
 	return wrapErrors(res, body, errs)
 }
@@ -279,7 +282,7 @@ func (api API) deleteWithData(path string, input interface{}) error {
 			return errRetry
 		}
 		return nil
-	}, api.newBackoff())
+	}, api.backoffStrategy())
 
 	// wrapping []errors into compatible error & making HTTPError
 	return wrapErrors(res, []byte(body), errs)

--- a/generic_test.go
+++ b/generic_test.go
@@ -8,6 +8,32 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
+func TestRetryDisabled(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusTooManyRequests)
+				w.Write([]byte(`{"error": "rate limited"}`)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	tested := &API{
+		ApiKey: "token",
+		Retry:  &RetryConfig{Enabled: false},
+	}
+	err := tested.delete("path1/:uuid", "uuid1")
+	if err == nil {
+		t.Fatal("Expected to fail with 429")
+	}
+	if requestCount != 1 {
+		t.Errorf("Expected exactly 1 request (no retries), got: %v", requestCount)
+	}
+}
+
 func TestRetryStatusTooManyRequests(t *testing.T) {
 	var i int
 	server := httptest.NewServer(

--- a/invoices.go
+++ b/invoices.go
@@ -16,11 +16,11 @@ type ValueChange struct {
 }
 
 const (
-	invoicesEndpoint              = "invoices"
-	singleInvoiceEndpoint         = "invoices/:uuid"
-	customersInvoicesEndpoint     = "import/customers/:customerUUID/invoices"
-	invoiceUpdateStatusEndpoint   = "data_sources/:dataSourceUUID/invoices/:externalID/status"
-	invoiceDisabledStateEndpoint  = "invoices/:uuid/disabled_state"
+	invoicesEndpoint             = "invoices"
+	singleInvoiceEndpoint        = "invoices/:uuid"
+	customersInvoicesEndpoint    = "import/customers/:customerUUID/invoices"
+	invoiceUpdateStatusEndpoint  = "data_sources/:dataSourceUUID/invoices/:externalID/status"
+	invoiceDisabledStateEndpoint = "invoices/:uuid/disabled_state"
 )
 
 // Invoices is wrapper for bulk importing invoices
@@ -98,7 +98,6 @@ type RetrieveInvoiceParams struct {
 
 // CreateInvoices loads an invoice to a customer in Chartmogul.
 // Customer must have a valid UUID! (use return value of API)
-//
 func (api API) CreateInvoices(invoices []*Invoice, customerUUID string) (*Invoices, error) {
 	if len(invoices) == 0 {
 		return nil, nil
@@ -111,7 +110,6 @@ func (api API) CreateInvoices(invoices []*Invoice, customerUUID string) (*Invoic
 }
 
 // ListInvoices lists all imported invoices for a customer.
-//
 func (api API) ListInvoices(cursor *Cursor, customerUUID string) (*Invoices, error) {
 	result := &Invoices{}
 	path := strings.Replace(customersInvoicesEndpoint, ":customerUUID", customerUUID, 1)
@@ -124,7 +122,6 @@ func (api API) ListInvoices(cursor *Cursor, customerUUID string) (*Invoices, err
 
 // ListAllInvoices lists all imported invoices. Use parameters to narrow down the search/for paging.
 // listAllInvoicesParams can be nil, in which case default values on API are used.
-//
 func (api API) ListAllInvoices(listAllInvoicesParams *ListAllInvoicesParams) (*Invoices, error) {
 	result := &Invoices{}
 	query := make([]interface{}, 0, 1)
@@ -136,7 +133,6 @@ func (api API) ListAllInvoices(listAllInvoicesParams *ListAllInvoicesParams) (*I
 
 // RetrieveInvoice returns one Invoice by UUID.
 // Optionally accepts RetrieveInvoiceParams for additional query options.
-//
 func (api API) RetrieveInvoice(invoiceUUID string, params ...*RetrieveInvoiceParams) (*Invoice, error) {
 	result := &Invoice{}
 
@@ -150,7 +146,6 @@ func (api API) RetrieveInvoice(invoiceUUID string, params ...*RetrieveInvoicePar
 }
 
 // DeleteInvoice deletes one invoice by UUID.
-//
 func (api API) DeleteInvoice(invoiceUUID string) error {
 	return api.delete(singleInvoiceEndpoint, invoiceUUID)
 }
@@ -161,7 +156,6 @@ type UpdateInvoiceStatusParams struct {
 }
 
 // UpdateInvoiceStatus updates the status of an invoice by data source UUID and invoice external ID.
-//
 func (api API) UpdateInvoiceStatus(dataSourceUUID, invoiceExternalID string, params *UpdateInvoiceStatusParams) error {
 	path := strings.Replace(invoiceUpdateStatusEndpoint, ":dataSourceUUID", dataSourceUUID, 1)
 	path = strings.Replace(path, ":externalID", invoiceExternalID, 1)
@@ -175,7 +169,6 @@ type ToggleInvoiceDisabledParams struct {
 }
 
 // ToggleInvoiceDisabled toggles the disabled state of an invoice.
-//
 func (api API) ToggleInvoiceDisabled(invoiceUUID string, params *ToggleInvoiceDisabledParams) (*Invoice, error) {
 	result := &Invoice{}
 	return result, api.update(invoiceDisabledStateEndpoint, invoiceUUID, params, result)

--- a/invoices.go
+++ b/invoices.go
@@ -99,7 +99,6 @@ type RetrieveInvoiceParams struct {
 // CreateInvoices loads an invoice to a customer in Chartmogul.
 // Customer must have a valid UUID! (use return value of API)
 //
-// See https://dev.chartmogul.com/reference/invoices
 func (api API) CreateInvoices(invoices []*Invoice, customerUUID string) (*Invoices, error) {
 	if len(invoices) == 0 {
 		return nil, nil
@@ -113,7 +112,6 @@ func (api API) CreateInvoices(invoices []*Invoice, customerUUID string) (*Invoic
 
 // ListInvoices lists all imported invoices for a customer.
 //
-// See https://dev.chartmogul.com/reference/invoices
 func (api API) ListInvoices(cursor *Cursor, customerUUID string) (*Invoices, error) {
 	result := &Invoices{}
 	path := strings.Replace(customersInvoicesEndpoint, ":customerUUID", customerUUID, 1)
@@ -127,7 +125,6 @@ func (api API) ListInvoices(cursor *Cursor, customerUUID string) (*Invoices, err
 // ListAllInvoices lists all imported invoices. Use parameters to narrow down the search/for paging.
 // listAllInvoicesParams can be nil, in which case default values on API are used.
 //
-// See https://dev.chartmogul.com/reference/invoices
 func (api API) ListAllInvoices(listAllInvoicesParams *ListAllInvoicesParams) (*Invoices, error) {
 	result := &Invoices{}
 	query := make([]interface{}, 0, 1)
@@ -140,7 +137,6 @@ func (api API) ListAllInvoices(listAllInvoicesParams *ListAllInvoicesParams) (*I
 // RetrieveInvoice returns one Invoice by UUID.
 // Optionally accepts RetrieveInvoiceParams for additional query options.
 //
-// See https://dev.chartmogul.com/reference/invoices
 func (api API) RetrieveInvoice(invoiceUUID string, params ...*RetrieveInvoiceParams) (*Invoice, error) {
 	result := &Invoice{}
 
@@ -155,7 +151,6 @@ func (api API) RetrieveInvoice(invoiceUUID string, params ...*RetrieveInvoicePar
 
 // DeleteInvoice deletes one invoice by UUID.
 //
-// See https://dev.chartmogul.com/reference/invoices
 func (api API) DeleteInvoice(invoiceUUID string) error {
 	return api.delete(singleInvoiceEndpoint, invoiceUUID)
 }
@@ -167,7 +162,6 @@ type UpdateInvoiceStatusParams struct {
 
 // UpdateInvoiceStatus updates the status of an invoice by data source UUID and invoice external ID.
 //
-// See https://dev.chartmogul.com/reference/invoices/update-status
 func (api API) UpdateInvoiceStatus(dataSourceUUID, invoiceExternalID string, params *UpdateInvoiceStatusParams) error {
 	path := strings.Replace(invoiceUpdateStatusEndpoint, ":dataSourceUUID", dataSourceUUID, 1)
 	path = strings.Replace(path, ":externalID", invoiceExternalID, 1)
@@ -182,7 +176,6 @@ type ToggleInvoiceDisabledParams struct {
 
 // ToggleInvoiceDisabled toggles the disabled state of an invoice.
 //
-// See https://dev.chartmogul.com/reference/invoices/disable
 func (api API) ToggleInvoiceDisabled(invoiceUUID string, params *ToggleInvoiceDisabledParams) (*Invoice, error) {
 	result := &Invoice{}
 	return result, api.update(invoiceDisabledStateEndpoint, invoiceUUID, params, result)

--- a/invoices.go
+++ b/invoices.go
@@ -16,9 +16,11 @@ type ValueChange struct {
 }
 
 const (
-	invoicesEndpoint          = "invoices"
-	singleInvoiceEndpoint     = "invoices/:uuid"
-	customersInvoicesEndpoint = "import/customers/:customerUUID/invoices"
+	invoicesEndpoint              = "invoices"
+	singleInvoiceEndpoint         = "invoices/:uuid"
+	customersInvoicesEndpoint     = "import/customers/:customerUUID/invoices"
+	invoiceUpdateStatusEndpoint   = "data_sources/:dataSourceUUID/invoices/:externalID/status"
+	invoiceDisabledStateEndpoint  = "invoices/:uuid/disabled_state"
 )
 
 // Invoices is wrapper for bulk importing invoices
@@ -51,28 +53,29 @@ type Invoice struct {
 
 // LineItem represents a singular items of the invoices
 type LineItem struct {
-	UUID                      string `json:"uuid,omitempty"`
-	AccountCode               string `json:"account_code,omitempty"`
-	AmountInCents             int    `json:"amount_in_cents"`
-	CancelledAt               string `json:"cancelled_at,omitempty"`
-	Description               string `json:"description,omitempty"`
-	DiscountAmountInCents     int    `json:"discount_amount_in_cents,omitempty"`
-	DiscountCode              string `json:"discount_code,omitempty"`
-	ExternalID                string `json:"external_id,omitempty"`
-	PlanUUID                  string `json:"plan_uuid,omitempty"`
-	Prorated                  bool   `json:"prorated,omitempty"`
-	Quantity                  int    `json:"quantity,omitempty"`
-	ServicePeriodEnd          string `json:"service_period_end,omitempty"`
-	ServicePeriodStart        string `json:"service_period_start,omitempty"`
-	SubscriptionExternalID    string `json:"subscription_external_id,omitempty"`
-	SubscriptionSetExternalID string `json:"subscription_set_external_id,omitempty"`
-	SubscriptionUUID          string `json:"subscription_uuid,omitempty"`
-	TaxAmountInCents          int    `json:"tax_amount_in_cents,omitempty"`
-	TransactionFeesInCents    int    `json:"transaction_fees_in_cents,omitempty"`
-	TransactionFeesCurrency   string `json:"transaction_fees_currency,omitempty"`
-	DiscountDescription       string `json:"discount_description,omitempty"`
-	EventOrder                int    `json:"event_order,omitempty"`
-	Type                      string `json:"type"`
+	UUID                      string      `json:"uuid,omitempty"`
+	AccountCode               string      `json:"account_code,omitempty"`
+	AmountInCents             int         `json:"amount_in_cents"`
+	CancelledAt               string      `json:"cancelled_at,omitempty"`
+	Description               string      `json:"description,omitempty"`
+	DiscountAmountInCents     int         `json:"discount_amount_in_cents,omitempty"`
+	DiscountCode              string      `json:"discount_code,omitempty"`
+	ExternalID                string      `json:"external_id,omitempty"`
+	PlanUUID                  string      `json:"plan_uuid,omitempty"`
+	Prorated                  bool        `json:"prorated,omitempty"`
+	Quantity                  int         `json:"quantity,omitempty"`
+	ServicePeriodEnd          string      `json:"service_period_end,omitempty"`
+	ServicePeriodStart        string      `json:"service_period_start,omitempty"`
+	SubscriptionExternalID    string      `json:"subscription_external_id,omitempty"`
+	SubscriptionSetExternalID string      `json:"subscription_set_external_id,omitempty"`
+	SubscriptionUUID          string      `json:"subscription_uuid,omitempty"`
+	TaxAmountInCents          int         `json:"tax_amount_in_cents,omitempty"`
+	TransactionFeesInCents    int         `json:"transaction_fees_in_cents,omitempty"`
+	TransactionFeesCurrency   string      `json:"transaction_fees_currency,omitempty"`
+	DiscountDescription       string      `json:"discount_description,omitempty"`
+	EventOrder                int         `json:"event_order,omitempty"`
+	Type                      string      `json:"type"`
+	Errors                    interface{} `json:"errors,omitempty"`
 }
 
 // ListAllInvoicesParams optional parameters for ListAllInvoices
@@ -96,7 +99,7 @@ type RetrieveInvoiceParams struct {
 // CreateInvoices loads an invoice to a customer in Chartmogul.
 // Customer must have a valid UUID! (use return value of API)
 //
-// See https://dev.chartmogul.com/v1.0/reference#invoices
+// See https://dev.chartmogul.com/reference/invoices
 func (api API) CreateInvoices(invoices []*Invoice, customerUUID string) (*Invoices, error) {
 	if len(invoices) == 0 {
 		return nil, nil
@@ -110,7 +113,7 @@ func (api API) CreateInvoices(invoices []*Invoice, customerUUID string) (*Invoic
 
 // ListInvoices lists all imported invoices for a customer.
 //
-// See https://dev.chartmogul.com/v1.0/reference#invoices
+// See https://dev.chartmogul.com/reference/invoices
 func (api API) ListInvoices(cursor *Cursor, customerUUID string) (*Invoices, error) {
 	result := &Invoices{}
 	path := strings.Replace(customersInvoicesEndpoint, ":customerUUID", customerUUID, 1)
@@ -124,7 +127,7 @@ func (api API) ListInvoices(cursor *Cursor, customerUUID string) (*Invoices, err
 // ListAllInvoices lists all imported invoices. Use parameters to narrow down the search/for paging.
 // listAllInvoicesParams can be nil, in which case default values on API are used.
 //
-// See https://dev.chartmogul.com/v1.0/reference#invoices
+// See https://dev.chartmogul.com/reference/invoices
 func (api API) ListAllInvoices(listAllInvoicesParams *ListAllInvoicesParams) (*Invoices, error) {
 	result := &Invoices{}
 	query := make([]interface{}, 0, 1)
@@ -137,7 +140,7 @@ func (api API) ListAllInvoices(listAllInvoicesParams *ListAllInvoicesParams) (*I
 // RetrieveInvoice returns one Invoice by UUID.
 // Optionally accepts RetrieveInvoiceParams for additional query options.
 //
-// See https://dev.chartmogul.com/v1.0/reference#invoices
+// See https://dev.chartmogul.com/reference/invoices
 func (api API) RetrieveInvoice(invoiceUUID string, params ...*RetrieveInvoiceParams) (*Invoice, error) {
 	result := &Invoice{}
 
@@ -152,7 +155,35 @@ func (api API) RetrieveInvoice(invoiceUUID string, params ...*RetrieveInvoicePar
 
 // DeleteInvoice deletes one invoice by UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#invoices
+// See https://dev.chartmogul.com/reference/invoices
 func (api API) DeleteInvoice(invoiceUUID string) error {
 	return api.delete(singleInvoiceEndpoint, invoiceUUID)
+}
+
+// UpdateInvoiceStatusParams holds the parameters for UpdateInvoiceStatus.
+type UpdateInvoiceStatusParams struct {
+	Status string `json:"status"`
+}
+
+// UpdateInvoiceStatus updates the status of an invoice by data source UUID and invoice external ID.
+//
+// See https://dev.chartmogul.com/reference/invoices/update-status
+func (api API) UpdateInvoiceStatus(dataSourceUUID, invoiceExternalID string, params *UpdateInvoiceStatusParams) error {
+	path := strings.Replace(invoiceUpdateStatusEndpoint, ":dataSourceUUID", dataSourceUUID, 1)
+	path = strings.Replace(path, ":externalID", invoiceExternalID, 1)
+	result := &Invoice{}
+	return api.update(path, "", params, result)
+}
+
+// ToggleInvoiceDisabledParams holds the parameters for ToggleInvoiceDisabled.
+type ToggleInvoiceDisabledParams struct {
+	Disabled bool `json:"disabled"`
+}
+
+// ToggleInvoiceDisabled toggles the disabled state of an invoice.
+//
+// See https://dev.chartmogul.com/reference/invoices/disable
+func (api API) ToggleInvoiceDisabled(invoiceUUID string, params *ToggleInvoiceDisabledParams) (*Invoice, error) {
+	result := &Invoice{}
+	return result, api.update(invoiceDisabledStateEndpoint, invoiceUUID, params, result)
 }

--- a/invoices_test.go
+++ b/invoices_test.go
@@ -554,6 +554,139 @@ func TestRetrieveInvoiceWithErrors(t *testing.T) {
 	}
 }
 
+func TestUpdateInvoiceStatus(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "PATCH"
+				if r.Method != expectedMethod {
+					t.Errorf("Requested method expected: %v, actual: %v", expectedMethod, r.Method)
+				}
+				expected := "/v/data_sources/ds_123/invoices/INV0001/status"
+				path := r.URL.Path
+				if path != expected {
+					t.Errorf("Requested path expected: %v, actual: %v", expected, path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+				defer r.Body.Close()
+				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal("error should be nil")
+				}
+				expectedBody := `{"status":"void"}`
+				if string(body) != expectedBody {
+					t.Errorf("Requested body expected: %v, actual: %v", expectedBody, string(body))
+				}
+				w.Write([]byte("{}")) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	err := tested.UpdateInvoiceStatus("ds_123", "INV0001", &UpdateInvoiceStatusParams{
+		Status: "void",
+	})
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+}
+
+func TestToggleInvoiceDisabled(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "PATCH"
+				if r.Method != expectedMethod {
+					t.Errorf("Requested method expected: %v, actual: %v", expectedMethod, r.Method)
+				}
+				expected := "/v/invoices/inv_123/disabled_state"
+				path := r.URL.Path
+				if path != expected {
+					t.Errorf("Requested path expected: %v, actual: %v", expected, path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+				defer r.Body.Close()
+				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal("error should be nil")
+				}
+				expectedBody := `{"disabled":true}`
+				if string(body) != expectedBody {
+					t.Errorf("Requested body expected: %v, actual: %v", expectedBody, string(body))
+				}
+				w.Write([]byte(`{"uuid":"inv_123","external_id":"INV0001","date":"2015-11-01T00:00:00.000Z","currency":"USD","disabled":true,"disabled_at":"2026-03-17T10:00:00.000Z","disabled_by":"user@example.com","line_items":[]}`)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	invoice, err := tested.ToggleInvoiceDisabled("inv_123", &ToggleInvoiceDisabledParams{
+		Disabled: true,
+	})
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if invoice.UUID != "inv_123" {
+		t.Errorf("Expected UUID inv_123, got: %v", invoice.UUID)
+	}
+	if invoice.Disabled == nil || *invoice.Disabled != true {
+		t.Error("Expected disabled to be true")
+	}
+	if invoice.DisabledAt != "2026-03-17T10:00:00.000Z" {
+		t.Errorf("Expected disabled_at, got: %v", invoice.DisabledAt)
+	}
+}
+
+func TestRetrieveInvoiceWithLineItemErrors(t *testing.T) {
+	const lineItemErrorsExample = `{
+		"uuid": "inv_789",
+		"external_id": "INV0003",
+		"date": "2015-11-01T00:00:00.000Z",
+		"currency": "USD",
+		"disabled": false,
+		"line_items": [
+			{
+				"uuid": "li_abc",
+				"type": "subscription",
+				"amount_in_cents": 5000,
+				"errors": {"service_period_start": ["is required"]}
+			}
+		],
+		"transactions": []
+	}`
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(lineItemErrorsExample)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	invoice, err := tested.RetrieveInvoice("inv_789")
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if len(invoice.LineItems) != 1 {
+		t.Fatalf("Expected 1 line item, got: %v", len(invoice.LineItems))
+	}
+	if invoice.LineItems[0].Errors == nil {
+		t.Error("Expected line item errors to be present")
+	}
+}
+
 func TestCreateInvoiceFullRefund(t *testing.T) {
 	server := httptest.NewServer(
 		http.HandlerFunc(

--- a/metrics.go
+++ b/metrics.go
@@ -195,7 +195,7 @@ const (
 
 // MetricsRetrieveAll retrieves all key metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/v1.0/reference#retrieve-all-key-metrics
+// See https://dev.chartmogul.com/reference/retrieve-all-key-metrics
 func (api API) MetricsRetrieveAll(metricsFilter *MetricsFilter) (*MetricsResult, error) {
 	output := &MetricsResult{}
 	err := api.list(metricsEndpoint, output, *metricsFilter)
@@ -204,7 +204,7 @@ func (api API) MetricsRetrieveAll(metricsFilter *MetricsFilter) (*MetricsResult,
 
 // MetricsRetrieveMRR retrieves the MRR metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/v1.0/reference#retrieve-mrr
+// See https://dev.chartmogul.com/reference/retrieve-mrr
 func (api API) MetricsRetrieveMRR(metricsFilter *MetricsFilter) (*MRRResult, error) {
 	output := &MRRResult{}
 	err := api.list(metricsMRREndpoint, output, *metricsFilter)
@@ -213,7 +213,7 @@ func (api API) MetricsRetrieveMRR(metricsFilter *MetricsFilter) (*MRRResult, err
 
 // MetricsRetrieveARR retrieves the ARR metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/v1.0/reference#retrieve-arr
+// See https://dev.chartmogul.com/reference/retrieve-arr
 func (api API) MetricsRetrieveARR(metricsFilter *MetricsFilter) (*ARRResult, error) {
 	output := &ARRResult{}
 	err := api.list(metricsARREndpoint, output, *metricsFilter)
@@ -222,7 +222,7 @@ func (api API) MetricsRetrieveARR(metricsFilter *MetricsFilter) (*ARRResult, err
 
 // MetricsRetrieveARPA retrieves the ARPA metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/v1.0/reference#retrieve-arpa
+// See https://dev.chartmogul.com/reference/retrieve-arpa
 func (api API) MetricsRetrieveARPA(metricsFilter *MetricsFilter) (*ARPAResult, error) {
 	output := &ARPAResult{}
 	err := api.list(metricsARPAEndpoint, output, *metricsFilter)
@@ -231,7 +231,7 @@ func (api API) MetricsRetrieveARPA(metricsFilter *MetricsFilter) (*ARPAResult, e
 
 // MetricsRetrieveASP retrieves the ASP metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/v1.0/reference#retrieve-asp
+// See https://dev.chartmogul.com/reference/retrieve-asp
 func (api API) MetricsRetrieveASP(metricsFilter *MetricsFilter) (*ASPResult, error) {
 	output := &ASPResult{}
 	err := api.list(metricsASPEndpoint, output, *metricsFilter)
@@ -240,7 +240,7 @@ func (api API) MetricsRetrieveASP(metricsFilter *MetricsFilter) (*ASPResult, err
 
 // MetricsRetrieveCustomerCount retrieves customer count, for the specified time period.
 //
-// See https://dev.chartmogul.com/v1.0/reference#retrieve-customer-count
+// See https://dev.chartmogul.com/reference/retrieve-customer-count
 func (api API) MetricsRetrieveCustomerCount(metricsFilter *MetricsFilter) (*CustomerCountResult, error) {
 	output := &CustomerCountResult{}
 	err := api.list(metricsCustomerCountEndpoint, output, *metricsFilter)
@@ -249,7 +249,7 @@ func (api API) MetricsRetrieveCustomerCount(metricsFilter *MetricsFilter) (*Cust
 
 // MetricsRetrieveCustomerChurnRate retrieves customer churn rate, for the specified time period.
 //
-// See https://dev.chartmogul.com/v1.0/reference#retrieve-customer-churn-rate
+// See https://dev.chartmogul.com/reference/retrieve-customer-churn-rate
 func (api API) MetricsRetrieveCustomerChurnRate(metricsFilter *MetricsFilter) (*CustomerChurnRateResult, error) {
 	output := &CustomerChurnRateResult{}
 	err := api.list(metricsCustomerChurnRateEndpoint, output, *metricsFilter)
@@ -258,7 +258,7 @@ func (api API) MetricsRetrieveCustomerChurnRate(metricsFilter *MetricsFilter) (*
 
 // MetricsRetrieveMRRChurnRate retrieves all key metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/v1.0/reference#retrieve-mrr-churn-rate
+// See https://dev.chartmogul.com/reference/retrieve-mrr-churn-rate
 func (api API) MetricsRetrieveMRRChurnRate(metricsFilter *MetricsFilter) (*MRRChurnRateResult, error) {
 	output := &MRRChurnRateResult{}
 	err := api.list(metricsMRRChurnRateEndpoint, output, *metricsFilter)
@@ -267,7 +267,7 @@ func (api API) MetricsRetrieveMRRChurnRate(metricsFilter *MetricsFilter) (*MRRCh
 
 // MetricsRetrieveLTV retrieves LTV metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/v1.0/reference#retrieve-ltv
+// See https://dev.chartmogul.com/reference/retrieve-ltv
 func (api API) MetricsRetrieveLTV(metricsFilter *MetricsFilter) (*LTVResult, error) {
 	output := &LTVResult{}
 	err := api.list(metricsLTVEndpoint, output, *metricsFilter)

--- a/metrics.go
+++ b/metrics.go
@@ -195,7 +195,6 @@ const (
 
 // MetricsRetrieveAll retrieves all key metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/reference/retrieve-all-key-metrics
 func (api API) MetricsRetrieveAll(metricsFilter *MetricsFilter) (*MetricsResult, error) {
 	output := &MetricsResult{}
 	err := api.list(metricsEndpoint, output, *metricsFilter)
@@ -204,7 +203,6 @@ func (api API) MetricsRetrieveAll(metricsFilter *MetricsFilter) (*MetricsResult,
 
 // MetricsRetrieveMRR retrieves the MRR metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/reference/retrieve-mrr
 func (api API) MetricsRetrieveMRR(metricsFilter *MetricsFilter) (*MRRResult, error) {
 	output := &MRRResult{}
 	err := api.list(metricsMRREndpoint, output, *metricsFilter)
@@ -213,7 +211,6 @@ func (api API) MetricsRetrieveMRR(metricsFilter *MetricsFilter) (*MRRResult, err
 
 // MetricsRetrieveARR retrieves the ARR metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/reference/retrieve-arr
 func (api API) MetricsRetrieveARR(metricsFilter *MetricsFilter) (*ARRResult, error) {
 	output := &ARRResult{}
 	err := api.list(metricsARREndpoint, output, *metricsFilter)
@@ -222,7 +219,6 @@ func (api API) MetricsRetrieveARR(metricsFilter *MetricsFilter) (*ARRResult, err
 
 // MetricsRetrieveARPA retrieves the ARPA metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/reference/retrieve-arpa
 func (api API) MetricsRetrieveARPA(metricsFilter *MetricsFilter) (*ARPAResult, error) {
 	output := &ARPAResult{}
 	err := api.list(metricsARPAEndpoint, output, *metricsFilter)
@@ -231,7 +227,6 @@ func (api API) MetricsRetrieveARPA(metricsFilter *MetricsFilter) (*ARPAResult, e
 
 // MetricsRetrieveASP retrieves the ASP metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/reference/retrieve-asp
 func (api API) MetricsRetrieveASP(metricsFilter *MetricsFilter) (*ASPResult, error) {
 	output := &ASPResult{}
 	err := api.list(metricsASPEndpoint, output, *metricsFilter)
@@ -240,7 +235,6 @@ func (api API) MetricsRetrieveASP(metricsFilter *MetricsFilter) (*ASPResult, err
 
 // MetricsRetrieveCustomerCount retrieves customer count, for the specified time period.
 //
-// See https://dev.chartmogul.com/reference/retrieve-customer-count
 func (api API) MetricsRetrieveCustomerCount(metricsFilter *MetricsFilter) (*CustomerCountResult, error) {
 	output := &CustomerCountResult{}
 	err := api.list(metricsCustomerCountEndpoint, output, *metricsFilter)
@@ -249,7 +243,6 @@ func (api API) MetricsRetrieveCustomerCount(metricsFilter *MetricsFilter) (*Cust
 
 // MetricsRetrieveCustomerChurnRate retrieves customer churn rate, for the specified time period.
 //
-// See https://dev.chartmogul.com/reference/retrieve-customer-churn-rate
 func (api API) MetricsRetrieveCustomerChurnRate(metricsFilter *MetricsFilter) (*CustomerChurnRateResult, error) {
 	output := &CustomerChurnRateResult{}
 	err := api.list(metricsCustomerChurnRateEndpoint, output, *metricsFilter)
@@ -258,7 +251,6 @@ func (api API) MetricsRetrieveCustomerChurnRate(metricsFilter *MetricsFilter) (*
 
 // MetricsRetrieveMRRChurnRate retrieves all key metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/reference/retrieve-mrr-churn-rate
 func (api API) MetricsRetrieveMRRChurnRate(metricsFilter *MetricsFilter) (*MRRChurnRateResult, error) {
 	output := &MRRChurnRateResult{}
 	err := api.list(metricsMRRChurnRateEndpoint, output, *metricsFilter)
@@ -267,7 +259,6 @@ func (api API) MetricsRetrieveMRRChurnRate(metricsFilter *MetricsFilter) (*MRRCh
 
 // MetricsRetrieveLTV retrieves LTV metrics, for the specified time period.
 //
-// See https://dev.chartmogul.com/reference/retrieve-ltv
 func (api API) MetricsRetrieveLTV(metricsFilter *MetricsFilter) (*LTVResult, error) {
 	output := &LTVResult{}
 	err := api.list(metricsLTVEndpoint, output, *metricsFilter)

--- a/metrics.go
+++ b/metrics.go
@@ -194,7 +194,6 @@ const (
 )
 
 // MetricsRetrieveAll retrieves all key metrics, for the specified time period.
-//
 func (api API) MetricsRetrieveAll(metricsFilter *MetricsFilter) (*MetricsResult, error) {
 	output := &MetricsResult{}
 	err := api.list(metricsEndpoint, output, *metricsFilter)
@@ -202,7 +201,6 @@ func (api API) MetricsRetrieveAll(metricsFilter *MetricsFilter) (*MetricsResult,
 }
 
 // MetricsRetrieveMRR retrieves the MRR metrics, for the specified time period.
-//
 func (api API) MetricsRetrieveMRR(metricsFilter *MetricsFilter) (*MRRResult, error) {
 	output := &MRRResult{}
 	err := api.list(metricsMRREndpoint, output, *metricsFilter)
@@ -210,7 +208,6 @@ func (api API) MetricsRetrieveMRR(metricsFilter *MetricsFilter) (*MRRResult, err
 }
 
 // MetricsRetrieveARR retrieves the ARR metrics, for the specified time period.
-//
 func (api API) MetricsRetrieveARR(metricsFilter *MetricsFilter) (*ARRResult, error) {
 	output := &ARRResult{}
 	err := api.list(metricsARREndpoint, output, *metricsFilter)
@@ -218,7 +215,6 @@ func (api API) MetricsRetrieveARR(metricsFilter *MetricsFilter) (*ARRResult, err
 }
 
 // MetricsRetrieveARPA retrieves the ARPA metrics, for the specified time period.
-//
 func (api API) MetricsRetrieveARPA(metricsFilter *MetricsFilter) (*ARPAResult, error) {
 	output := &ARPAResult{}
 	err := api.list(metricsARPAEndpoint, output, *metricsFilter)
@@ -226,7 +222,6 @@ func (api API) MetricsRetrieveARPA(metricsFilter *MetricsFilter) (*ARPAResult, e
 }
 
 // MetricsRetrieveASP retrieves the ASP metrics, for the specified time period.
-//
 func (api API) MetricsRetrieveASP(metricsFilter *MetricsFilter) (*ASPResult, error) {
 	output := &ASPResult{}
 	err := api.list(metricsASPEndpoint, output, *metricsFilter)
@@ -234,7 +229,6 @@ func (api API) MetricsRetrieveASP(metricsFilter *MetricsFilter) (*ASPResult, err
 }
 
 // MetricsRetrieveCustomerCount retrieves customer count, for the specified time period.
-//
 func (api API) MetricsRetrieveCustomerCount(metricsFilter *MetricsFilter) (*CustomerCountResult, error) {
 	output := &CustomerCountResult{}
 	err := api.list(metricsCustomerCountEndpoint, output, *metricsFilter)
@@ -242,7 +236,6 @@ func (api API) MetricsRetrieveCustomerCount(metricsFilter *MetricsFilter) (*Cust
 }
 
 // MetricsRetrieveCustomerChurnRate retrieves customer churn rate, for the specified time period.
-//
 func (api API) MetricsRetrieveCustomerChurnRate(metricsFilter *MetricsFilter) (*CustomerChurnRateResult, error) {
 	output := &CustomerChurnRateResult{}
 	err := api.list(metricsCustomerChurnRateEndpoint, output, *metricsFilter)
@@ -250,7 +243,6 @@ func (api API) MetricsRetrieveCustomerChurnRate(metricsFilter *MetricsFilter) (*
 }
 
 // MetricsRetrieveMRRChurnRate retrieves all key metrics, for the specified time period.
-//
 func (api API) MetricsRetrieveMRRChurnRate(metricsFilter *MetricsFilter) (*MRRChurnRateResult, error) {
 	output := &MRRChurnRateResult{}
 	err := api.list(metricsMRRChurnRateEndpoint, output, *metricsFilter)
@@ -258,7 +250,6 @@ func (api API) MetricsRetrieveMRRChurnRate(metricsFilter *MetricsFilter) (*MRRCh
 }
 
 // MetricsRetrieveLTV retrieves LTV metrics, for the specified time period.
-//
 func (api API) MetricsRetrieveLTV(metricsFilter *MetricsFilter) (*LTVResult, error) {
 	output := &LTVResult{}
 	err := api.list(metricsLTVEndpoint, output, *metricsFilter)

--- a/metrics_activities_exports.go
+++ b/metrics_activities_exports.go
@@ -37,7 +37,7 @@ const (
 
 // MetricsCreateActivitiesExport requests creation of an activities export in Chartmogul.
 //
-// See https://dev.chartmogul.com/v1.0/reference#activities_export
+// See https://dev.chartmogul.com/reference/activities_export
 func (api API) MetricsCreateActivitiesExport(CreateMetricsActivitiesExportParam *CreateMetricsActivitiesExportParam) (*MetricsActivitiesExport, error) {
 	result := &MetricsActivitiesExport{}
 	return result, api.create(metricsActivitiesExportEndpoint, CreateMetricsActivitiesExportParam, result)
@@ -45,7 +45,7 @@ func (api API) MetricsCreateActivitiesExport(CreateMetricsActivitiesExportParam 
 
 // MetricsRetrieveActivitiesExport returns one activities export as in API.
 //
-// See https://dev.chartmogul.com/v1.0/reference#activities_export
+// See https://dev.chartmogul.com/reference/activities_export
 func (api API) MetricsRetrieveActivitiesExport(activitiesExportUUID string) (*MetricsActivitiesExport, error) {
 	result := &MetricsActivitiesExport{}
 	return result, api.retrieve(singleMetricsActivitiesExportEndpoint, activitiesExportUUID, result)

--- a/metrics_activities_exports.go
+++ b/metrics_activities_exports.go
@@ -36,14 +36,12 @@ const (
 )
 
 // MetricsCreateActivitiesExport requests creation of an activities export in Chartmogul.
-//
 func (api API) MetricsCreateActivitiesExport(CreateMetricsActivitiesExportParam *CreateMetricsActivitiesExportParam) (*MetricsActivitiesExport, error) {
 	result := &MetricsActivitiesExport{}
 	return result, api.create(metricsActivitiesExportEndpoint, CreateMetricsActivitiesExportParam, result)
 }
 
 // MetricsRetrieveActivitiesExport returns one activities export as in API.
-//
 func (api API) MetricsRetrieveActivitiesExport(activitiesExportUUID string) (*MetricsActivitiesExport, error) {
 	result := &MetricsActivitiesExport{}
 	return result, api.retrieve(singleMetricsActivitiesExportEndpoint, activitiesExportUUID, result)

--- a/metrics_activities_exports.go
+++ b/metrics_activities_exports.go
@@ -37,7 +37,6 @@ const (
 
 // MetricsCreateActivitiesExport requests creation of an activities export in Chartmogul.
 //
-// See https://dev.chartmogul.com/reference/activities_export
 func (api API) MetricsCreateActivitiesExport(CreateMetricsActivitiesExportParam *CreateMetricsActivitiesExportParam) (*MetricsActivitiesExport, error) {
 	result := &MetricsActivitiesExport{}
 	return result, api.create(metricsActivitiesExportEndpoint, CreateMetricsActivitiesExportParam, result)
@@ -45,7 +44,6 @@ func (api API) MetricsCreateActivitiesExport(CreateMetricsActivitiesExportParam 
 
 // MetricsRetrieveActivitiesExport returns one activities export as in API.
 //
-// See https://dev.chartmogul.com/reference/activities_export
 func (api API) MetricsRetrieveActivitiesExport(activitiesExportUUID string) (*MetricsActivitiesExport, error) {
 	result := &MetricsActivitiesExport{}
 	return result, api.retrieve(singleMetricsActivitiesExportEndpoint, activitiesExportUUID, result)

--- a/metrics_customer_activities.go
+++ b/metrics_customer_activities.go
@@ -24,7 +24,6 @@ type MetricsCustomerActivities struct {
 const metricsCustomerActivitiesEndpoint = "customers/:uuid/activities"
 
 // MetricsListCustomerActivities lists all activities for cutomer of a given UUID.
-//
 func (api API) MetricsListCustomerActivities(cursor *Cursor, customerUUID string) (*MetricsCustomerActivities, error) {
 	result := &MetricsCustomerActivities{}
 	path := strings.Replace(metricsCustomerActivitiesEndpoint, ":uuid", customerUUID, 1)

--- a/metrics_customer_activities.go
+++ b/metrics_customer_activities.go
@@ -25,7 +25,6 @@ const metricsCustomerActivitiesEndpoint = "customers/:uuid/activities"
 
 // MetricsListCustomerActivities lists all activities for cutomer of a given UUID.
 //
-// See https://dev.chartmogul.com/reference/list-customer-activities
 func (api API) MetricsListCustomerActivities(cursor *Cursor, customerUUID string) (*MetricsCustomerActivities, error) {
 	result := &MetricsCustomerActivities{}
 	path := strings.Replace(metricsCustomerActivitiesEndpoint, ":uuid", customerUUID, 1)

--- a/metrics_customer_activities.go
+++ b/metrics_customer_activities.go
@@ -25,7 +25,7 @@ const metricsCustomerActivitiesEndpoint = "customers/:uuid/activities"
 
 // MetricsListCustomerActivities lists all activities for cutomer of a given UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#list-customer-activities
+// See https://dev.chartmogul.com/reference/list-customer-activities
 func (api API) MetricsListCustomerActivities(cursor *Cursor, customerUUID string) (*MetricsCustomerActivities, error) {
 	result := &MetricsCustomerActivities{}
 	path := strings.Replace(metricsCustomerActivitiesEndpoint, ":uuid", customerUUID, 1)

--- a/metrics_customer_subscriptions.go
+++ b/metrics_customer_subscriptions.go
@@ -41,7 +41,6 @@ const metricsCustomerSubscriptionsEndpoint = "customers/:uuid/subscriptions"
 
 // MetricsListCustomerSubscriptions lists all subscriptions for customer of a given UUID.
 //
-// See https://dev.chartmogul.com/reference/subscriptions/list
 func (api API) MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID string) (*MetricsCustomerSubscriptions, error) {
 	result := &MetricsCustomerSubscriptions{}
 	path := strings.Replace(metricsCustomerSubscriptionsEndpoint, ":uuid", customerUUID, 1)
@@ -54,7 +53,6 @@ func (api API) MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID str
 
 // MetricsConnectSubscriptions connects subscription objects for a customer.
 //
-// See https://dev.chartmogul.com/reference/subscriptions/connect
 func (api API) MetricsConnectSubscriptions(dataSourceUUID string, customerUUID string, subscriptions []*MetricsCustomerSubscription) error {
 	path := strings.Replace(connectSubscriptionEndpoint, ":uuid", customerUUID, 1)
 
@@ -73,7 +71,6 @@ func (api API) MetricsConnectSubscriptions(dataSourceUUID string, customerUUID s
 
 // MetricsDisconnectSubscriptions disconnects subscription objects for a customer.
 //
-// See https://dev.chartmogul.com/reference/subscriptions/disconnect
 func (api API) MetricsDisconnectSubscriptions(dataSourceUUID string, customerUUID string, subscriptions []*MetricsCustomerSubscription) error {
 	path := strings.Replace(disconnectSubscriptionEndpoint, ":uuid", customerUUID, 1)
 

--- a/metrics_customer_subscriptions.go
+++ b/metrics_customer_subscriptions.go
@@ -40,7 +40,6 @@ type MetricsSubscriptionReference struct {
 const metricsCustomerSubscriptionsEndpoint = "customers/:uuid/subscriptions"
 
 // MetricsListCustomerSubscriptions lists all subscriptions for customer of a given UUID.
-//
 func (api API) MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID string) (*MetricsCustomerSubscriptions, error) {
 	result := &MetricsCustomerSubscriptions{}
 	path := strings.Replace(metricsCustomerSubscriptionsEndpoint, ":uuid", customerUUID, 1)
@@ -52,7 +51,6 @@ func (api API) MetricsListCustomerSubscriptions(cursor *Cursor, customerUUID str
 }
 
 // MetricsConnectSubscriptions connects subscription objects for a customer.
-//
 func (api API) MetricsConnectSubscriptions(dataSourceUUID string, customerUUID string, subscriptions []*MetricsCustomerSubscription) error {
 	path := strings.Replace(connectSubscriptionEndpoint, ":uuid", customerUUID, 1)
 
@@ -70,7 +68,6 @@ func (api API) MetricsConnectSubscriptions(dataSourceUUID string, customerUUID s
 }
 
 // MetricsDisconnectSubscriptions disconnects subscription objects for a customer.
-//
 func (api API) MetricsDisconnectSubscriptions(dataSourceUUID string, customerUUID string, subscriptions []*MetricsCustomerSubscription) error {
 	path := strings.Replace(disconnectSubscriptionEndpoint, ":uuid", customerUUID, 1)
 

--- a/mock_chartmogul/chartmogul.go
+++ b/mock_chartmogul/chartmogul.go
@@ -882,18 +882,22 @@ func (mr *MockIApiMockRecorder) RemoveTagsFromCustomer(arg0, arg1 interface{}) *
 }
 
 // RetrieveAccount mocks base method.
-func (m *MockIApi) RetrieveAccount() (*chartmogul.Account, error) {
+func (m *MockIApi) RetrieveAccount(arg0 ...*chartmogul.RetrieveAccountParams) (*chartmogul.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RetrieveAccount")
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RetrieveAccount", varargs...)
 	ret0, _ := ret[0].(*chartmogul.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RetrieveAccount indicates an expected call of RetrieveAccount.
-func (mr *MockIApiMockRecorder) RetrieveAccount() *gomock.Call {
+func (mr *MockIApiMockRecorder) RetrieveAccount(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAccount", reflect.TypeOf((*MockIApi)(nil).RetrieveAccount))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAccount", reflect.TypeOf((*MockIApi)(nil).RetrieveAccount), arg0...)
 }
 
 // RetrieveContact mocks base method.
@@ -1119,4 +1123,63 @@ func (m *MockIApi) UpdateSubscriptionEvent(arg0 *chartmogul.SubscriptionEvent) (
 func (mr *MockIApiMockRecorder) UpdateSubscriptionEvent(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubscriptionEvent", reflect.TypeOf((*MockIApi)(nil).UpdateSubscriptionEvent), arg0)
+}
+
+// ToggleSubscriptionEventDisabled mocks base method.
+func (m *MockIApi) ToggleSubscriptionEventDisabled(arg0 string, arg1 *chartmogul.ToggleSubscriptionEventDisabledParams) (*chartmogul.SubscriptionEvent, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ToggleSubscriptionEventDisabled", arg0, arg1)
+	ret0, _ := ret[0].(*chartmogul.SubscriptionEvent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ToggleSubscriptionEventDisabled indicates an expected call of ToggleSubscriptionEventDisabled.
+func (mr *MockIApiMockRecorder) ToggleSubscriptionEventDisabled(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToggleSubscriptionEventDisabled", reflect.TypeOf((*MockIApi)(nil).ToggleSubscriptionEventDisabled), arg0, arg1)
+}
+
+// ToggleSubscriptionEventDisabledByExternalID mocks base method.
+func (m *MockIApi) ToggleSubscriptionEventDisabledByExternalID(arg0 *chartmogul.ToggleSubscriptionEventDisabledByExternalIDParams) (*chartmogul.SubscriptionEvent, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ToggleSubscriptionEventDisabledByExternalID", arg0)
+	ret0, _ := ret[0].(*chartmogul.SubscriptionEvent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ToggleSubscriptionEventDisabledByExternalID indicates an expected call of ToggleSubscriptionEventDisabledByExternalID.
+func (mr *MockIApiMockRecorder) ToggleSubscriptionEventDisabledByExternalID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToggleSubscriptionEventDisabledByExternalID", reflect.TypeOf((*MockIApi)(nil).ToggleSubscriptionEventDisabledByExternalID), arg0)
+}
+
+// UpdateInvoiceStatus mocks base method.
+func (m *MockIApi) UpdateInvoiceStatus(arg0, arg1 string, arg2 *chartmogul.UpdateInvoiceStatusParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateInvoiceStatus", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateInvoiceStatus indicates an expected call of UpdateInvoiceStatus.
+func (mr *MockIApiMockRecorder) UpdateInvoiceStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInvoiceStatus", reflect.TypeOf((*MockIApi)(nil).UpdateInvoiceStatus), arg0, arg1, arg2)
+}
+
+// ToggleInvoiceDisabled mocks base method.
+func (m *MockIApi) ToggleInvoiceDisabled(arg0 string, arg1 *chartmogul.ToggleInvoiceDisabledParams) (*chartmogul.Invoice, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ToggleInvoiceDisabled", arg0, arg1)
+	ret0, _ := ret[0].(*chartmogul.Invoice)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ToggleInvoiceDisabled indicates an expected call of ToggleInvoiceDisabled.
+func (mr *MockIApiMockRecorder) ToggleInvoiceDisabled(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToggleInvoiceDisabled", reflect.TypeOf((*MockIApi)(nil).ToggleInvoiceDisabled), arg0, arg1)
 }

--- a/notes.go
+++ b/notes.go
@@ -55,7 +55,6 @@ const (
 
 // CreateCustomerNote loads the customer note to Chartmogul
 //
-// See https://dev.chartmogul.com/reference/create-a-customer-note
 func (api API) CreateNote(input *NewNote) (*Note, error) {
 	result := &Note{}
 	return result, api.create(customerNotesEndpoint, input, result)
@@ -63,7 +62,6 @@ func (api API) CreateNote(input *NewNote) (*Note, error) {
 
 // RetrieveCustomerNote returns one customer note as in API.
 //
-// See https://dev.chartmogul.com/reference/retrieve-a-customer-note
 func (api API) RetrieveNote(customerNoteUUID string) (*Note, error) {
 	result := &Note{}
 	return result, api.retrieve(singleCustomerNoteEndpoint, customerNoteUUID, result)
@@ -71,7 +69,6 @@ func (api API) RetrieveNote(customerNoteUUID string) (*Note, error) {
 
 // UpdateNote updates one customer note in API.
 //
-// See https://dev.chartmogul.com/reference/update-a-customer-note
 func (api API) UpdateNote(input *UpdateNote, customerNoteUUID string) (*Note, error) {
 	output := &Note{}
 	return output, api.update(singleCustomerNoteEndpoint, customerNoteUUID, input, output)
@@ -79,7 +76,6 @@ func (api API) UpdateNote(input *UpdateNote, customerNoteUUID string) (*Note, er
 
 // ListNotes lists all Notes
 //
-// See https://dev.chartmogul.com/reference/list-all-customer-notes
 func (api API) ListNotes(listNotesParams *ListNotesParams) (*Notes, error) {
 	result := &Notes{}
 	query := make([]interface{}, 0, 1)
@@ -91,7 +87,6 @@ func (api API) ListNotes(listNotesParams *ListNotesParams) (*Notes, error) {
 
 // DeleteNote deletes one customer note by UUID.
 //
-// See https://dev.chartmogul.com/reference/delete-a-customer-note
 func (api API) DeleteNote(customerNoteUUID string) error {
 	return api.delete(singleCustomerNoteEndpoint, customerNoteUUID)
 }

--- a/notes.go
+++ b/notes.go
@@ -54,28 +54,24 @@ const (
 )
 
 // CreateCustomerNote loads the customer note to Chartmogul
-//
 func (api API) CreateNote(input *NewNote) (*Note, error) {
 	result := &Note{}
 	return result, api.create(customerNotesEndpoint, input, result)
 }
 
 // RetrieveCustomerNote returns one customer note as in API.
-//
 func (api API) RetrieveNote(customerNoteUUID string) (*Note, error) {
 	result := &Note{}
 	return result, api.retrieve(singleCustomerNoteEndpoint, customerNoteUUID, result)
 }
 
 // UpdateNote updates one customer note in API.
-//
 func (api API) UpdateNote(input *UpdateNote, customerNoteUUID string) (*Note, error) {
 	output := &Note{}
 	return output, api.update(singleCustomerNoteEndpoint, customerNoteUUID, input, output)
 }
 
 // ListNotes lists all Notes
-//
 func (api API) ListNotes(listNotesParams *ListNotesParams) (*Notes, error) {
 	result := &Notes{}
 	query := make([]interface{}, 0, 1)
@@ -86,7 +82,6 @@ func (api API) ListNotes(listNotesParams *ListNotesParams) (*Notes, error) {
 }
 
 // DeleteNote deletes one customer note by UUID.
-//
 func (api API) DeleteNote(customerNoteUUID string) error {
 	return api.delete(singleCustomerNoteEndpoint, customerNoteUUID)
 }

--- a/opportunities.go
+++ b/opportunities.go
@@ -66,28 +66,24 @@ const (
 )
 
 // CreateOpportunity create the opportunity to Chartmogul
-//
 func (api API) CreateOpportunity(input *NewOpportunity) (*Opportunity, error) {
 	result := &Opportunity{}
 	return result, api.create(opportunitiesEndpoint, input, result)
 }
 
 // RetrieveOpportunity returns one opportunity as in API.
-//
 func (api API) RetrieveOpportunity(opportunityUUID string) (*Opportunity, error) {
 	result := &Opportunity{}
 	return result, api.retrieve(singleOpportunityEndpoint, opportunityUUID, result)
 }
 
 // UpdateOpportunity updates one opportunity in API.
-//
 func (api API) UpdateOpportunity(input *UpdateOpportunity, opportunityUUID string) (*Opportunity, error) {
 	output := &Opportunity{}
 	return output, api.update(singleOpportunityEndpoint, opportunityUUID, input, output)
 }
 
 // ListOpportunities lists all opportunities.
-//
 func (api API) ListOpportunities(listOpportunitiesParams *ListOpportunitiesParams) (*Opportunities, error) {
 	result := &Opportunities{}
 	query := make([]interface{}, 0, 1)
@@ -98,7 +94,6 @@ func (api API) ListOpportunities(listOpportunitiesParams *ListOpportunitiesParam
 }
 
 // DeleteOpportunity deletes one opportunity by UUID.
-//
 func (api API) DeleteOpportunity(opportunityUUID string) error {
 	return api.delete(singleOpportunityEndpoint, opportunityUUID)
 }

--- a/opportunities.go
+++ b/opportunities.go
@@ -67,7 +67,6 @@ const (
 
 // CreateOpportunity create the opportunity to Chartmogul
 //
-// See https://dev.chartmogul.com/reference/create-an-opportunity
 func (api API) CreateOpportunity(input *NewOpportunity) (*Opportunity, error) {
 	result := &Opportunity{}
 	return result, api.create(opportunitiesEndpoint, input, result)
@@ -75,7 +74,6 @@ func (api API) CreateOpportunity(input *NewOpportunity) (*Opportunity, error) {
 
 // RetrieveOpportunity returns one opportunity as in API.
 //
-// See https://dev.chartmogul.com/reference/retrieve-an-opportunity
 func (api API) RetrieveOpportunity(opportunityUUID string) (*Opportunity, error) {
 	result := &Opportunity{}
 	return result, api.retrieve(singleOpportunityEndpoint, opportunityUUID, result)
@@ -83,7 +81,6 @@ func (api API) RetrieveOpportunity(opportunityUUID string) (*Opportunity, error)
 
 // UpdateOpportunity updates one opportunity in API.
 //
-// See https://dev.chartmogul.com/reference/update-an-opportunity
 func (api API) UpdateOpportunity(input *UpdateOpportunity, opportunityUUID string) (*Opportunity, error) {
 	output := &Opportunity{}
 	return output, api.update(singleOpportunityEndpoint, opportunityUUID, input, output)
@@ -91,7 +88,6 @@ func (api API) UpdateOpportunity(input *UpdateOpportunity, opportunityUUID strin
 
 // ListOpportunities lists all opportunities.
 //
-// See https://dev.chartmogul.com/reference/list-opportunities
 func (api API) ListOpportunities(listOpportunitiesParams *ListOpportunitiesParams) (*Opportunities, error) {
 	result := &Opportunities{}
 	query := make([]interface{}, 0, 1)
@@ -103,7 +99,6 @@ func (api API) ListOpportunities(listOpportunitiesParams *ListOpportunitiesParam
 
 // DeleteOpportunity deletes one opportunity by UUID.
 //
-// See https://dev.chartmogul.com/reference/delete-an-opportunity
 func (api API) DeleteOpportunity(opportunityUUID string) error {
 	return api.delete(singleOpportunityEndpoint, opportunityUUID)
 }

--- a/ping.go
+++ b/ping.go
@@ -13,7 +13,6 @@ const pingEndpoint = "ping"
 
 // Ping is the authentication test endpoint. Doesn't retry on 429.
 //
-// See https://dev.chartmogul.com/docs/authentication
 func (api API) Ping() (bool, error) {
 	ping := &Ping{}
 	res, body, errs := api.req(gorequest.New().Get(prepareURL(pingEndpoint))).EndStruct(ping)

--- a/ping.go
+++ b/ping.go
@@ -12,7 +12,6 @@ type Ping struct {
 const pingEndpoint = "ping"
 
 // Ping is the authentication test endpoint. Doesn't retry on 429.
-//
 func (api API) Ping() (bool, error) {
 	ping := &Ping{}
 	res, body, errs := api.req(gorequest.New().Get(prepareURL(pingEndpoint))).EndStruct(ping)

--- a/ping.go
+++ b/ping.go
@@ -13,7 +13,7 @@ const pingEndpoint = "ping"
 
 // Ping is the authentication test endpoint. Doesn't retry on 429.
 //
-// See https://dev.chartmogul.com/v1.0/docs/authentication
+// See https://dev.chartmogul.com/docs/authentication
 func (api API) Ping() (bool, error) {
 	ping := &Ping{}
 	res, body, errs := api.req(gorequest.New().Get(prepareURL(pingEndpoint))).EndStruct(ping)

--- a/plan_group_plans.go
+++ b/plan_group_plans.go
@@ -18,7 +18,6 @@ type PlanGroupPlans struct {
 
 // ListPlanGroupPlans returns list of plans in with a plan group given the plan group uuid.
 //
-// See https://dev.chartmogul.com/reference/plan_groups
 func (api API) ListPlanGroupPlans(cursor *Cursor, planGroupUUID string) (*PlanGroupPlans, error) {
 	result := &PlanGroupPlans{}
 	query := make([]interface{}, 0, 1)

--- a/plan_group_plans.go
+++ b/plan_group_plans.go
@@ -17,7 +17,6 @@ type PlanGroupPlans struct {
 }
 
 // ListPlanGroupPlans returns list of plans in with a plan group given the plan group uuid.
-//
 func (api API) ListPlanGroupPlans(cursor *Cursor, planGroupUUID string) (*PlanGroupPlans, error) {
 	result := &PlanGroupPlans{}
 	query := make([]interface{}, 0, 1)

--- a/plan_group_plans.go
+++ b/plan_group_plans.go
@@ -18,7 +18,7 @@ type PlanGroupPlans struct {
 
 // ListPlanGroupPlans returns list of plans in with a plan group given the plan group uuid.
 //
-// See https://dev.chartmogul.com/v1.0/reference#plan_groups
+// See https://dev.chartmogul.com/reference/plan_groups
 func (api API) ListPlanGroupPlans(cursor *Cursor, planGroupUUID string) (*PlanGroupPlans, error) {
 	result := &PlanGroupPlans{}
 	query := make([]interface{}, 0, 1)

--- a/plan_groups.go
+++ b/plan_groups.go
@@ -22,7 +22,7 @@ type PlanGroups struct {
 
 // CreatePlanGroup creates plan group with given name and plans.
 //
-// See https://dev.chartmogul.com/v1.0/reference#plan_groups
+// See https://dev.chartmogul.com/reference/plan_groups
 func (api API) CreatePlanGroup(planGroup *PlanGroup) (result *PlanGroup, err error) {
 	result = &PlanGroup{}
 	return result, api.create(planGroupsEndpoint, planGroup, result)
@@ -30,7 +30,7 @@ func (api API) CreatePlanGroup(planGroup *PlanGroup) (result *PlanGroup, err err
 
 // RetrievePlanGroup returns one plan group by UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#plan_groups
+// See https://dev.chartmogul.com/reference/plan_groups
 func (api API) RetrievePlanGroup(planGroupUUID string) (*PlanGroup, error) {
 	result := &PlanGroup{}
 	return result, api.retrieve(singlePlanGroupEndpoint, planGroupUUID, result)
@@ -38,7 +38,7 @@ func (api API) RetrievePlanGroup(planGroupUUID string) (*PlanGroup, error) {
 
 // ListPlanGroups returns list of plan groups.
 //
-// See https://dev.chartmogul.com/v1.0/reference#plan_groups
+// See https://dev.chartmogul.com/reference/plan_groups
 func (api API) ListPlanGroups(cursor *Cursor) (*PlanGroups, error) {
 	result := &PlanGroups{}
 	query := make([]interface{}, 0, 1)
@@ -50,7 +50,7 @@ func (api API) ListPlanGroups(cursor *Cursor) (*PlanGroups, error) {
 
 // UpdatePlanGroup updates a name or plans.
 //
-// See https://dev.chartmogul.com/v1.0/reference#plan_groups
+// See https://dev.chartmogul.com/reference/plan_groups
 func (api API) UpdatePlanGroup(planGroup *PlanGroup, planGroupUUID string) (*PlanGroup, error) {
 	result := &PlanGroup{}
 	return result, api.update(singlePlanGroupEndpoint, planGroupUUID, planGroup, result)
@@ -58,7 +58,7 @@ func (api API) UpdatePlanGroup(planGroup *PlanGroup, planGroupUUID string) (*Pla
 
 // DeletePlanGroup deletes one plan group by UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#plan_groups
+// See https://dev.chartmogul.com/reference/plan_groups
 func (api API) DeletePlanGroup(planGroupUUID string) error {
 	return api.delete(singlePlanGroupEndpoint, planGroupUUID)
 }

--- a/plan_groups.go
+++ b/plan_groups.go
@@ -22,7 +22,6 @@ type PlanGroups struct {
 
 // CreatePlanGroup creates plan group with given name and plans.
 //
-// See https://dev.chartmogul.com/reference/plan_groups
 func (api API) CreatePlanGroup(planGroup *PlanGroup) (result *PlanGroup, err error) {
 	result = &PlanGroup{}
 	return result, api.create(planGroupsEndpoint, planGroup, result)
@@ -30,7 +29,6 @@ func (api API) CreatePlanGroup(planGroup *PlanGroup) (result *PlanGroup, err err
 
 // RetrievePlanGroup returns one plan group by UUID.
 //
-// See https://dev.chartmogul.com/reference/plan_groups
 func (api API) RetrievePlanGroup(planGroupUUID string) (*PlanGroup, error) {
 	result := &PlanGroup{}
 	return result, api.retrieve(singlePlanGroupEndpoint, planGroupUUID, result)
@@ -38,7 +36,6 @@ func (api API) RetrievePlanGroup(planGroupUUID string) (*PlanGroup, error) {
 
 // ListPlanGroups returns list of plan groups.
 //
-// See https://dev.chartmogul.com/reference/plan_groups
 func (api API) ListPlanGroups(cursor *Cursor) (*PlanGroups, error) {
 	result := &PlanGroups{}
 	query := make([]interface{}, 0, 1)
@@ -50,7 +47,6 @@ func (api API) ListPlanGroups(cursor *Cursor) (*PlanGroups, error) {
 
 // UpdatePlanGroup updates a name or plans.
 //
-// See https://dev.chartmogul.com/reference/plan_groups
 func (api API) UpdatePlanGroup(planGroup *PlanGroup, planGroupUUID string) (*PlanGroup, error) {
 	result := &PlanGroup{}
 	return result, api.update(singlePlanGroupEndpoint, planGroupUUID, planGroup, result)
@@ -58,7 +54,6 @@ func (api API) UpdatePlanGroup(planGroup *PlanGroup, planGroupUUID string) (*Pla
 
 // DeletePlanGroup deletes one plan group by UUID.
 //
-// See https://dev.chartmogul.com/reference/plan_groups
 func (api API) DeletePlanGroup(planGroupUUID string) error {
 	return api.delete(singlePlanGroupEndpoint, planGroupUUID)
 }

--- a/plan_groups.go
+++ b/plan_groups.go
@@ -21,21 +21,18 @@ type PlanGroups struct {
 }
 
 // CreatePlanGroup creates plan group with given name and plans.
-//
 func (api API) CreatePlanGroup(planGroup *PlanGroup) (result *PlanGroup, err error) {
 	result = &PlanGroup{}
 	return result, api.create(planGroupsEndpoint, planGroup, result)
 }
 
 // RetrievePlanGroup returns one plan group by UUID.
-//
 func (api API) RetrievePlanGroup(planGroupUUID string) (*PlanGroup, error) {
 	result := &PlanGroup{}
 	return result, api.retrieve(singlePlanGroupEndpoint, planGroupUUID, result)
 }
 
 // ListPlanGroups returns list of plan groups.
-//
 func (api API) ListPlanGroups(cursor *Cursor) (*PlanGroups, error) {
 	result := &PlanGroups{}
 	query := make([]interface{}, 0, 1)
@@ -46,14 +43,12 @@ func (api API) ListPlanGroups(cursor *Cursor) (*PlanGroups, error) {
 }
 
 // UpdatePlanGroup updates a name or plans.
-//
 func (api API) UpdatePlanGroup(planGroup *PlanGroup, planGroupUUID string) (*PlanGroup, error) {
 	result := &PlanGroup{}
 	return result, api.update(singlePlanGroupEndpoint, planGroupUUID, planGroup, result)
 }
 
 // DeletePlanGroup deletes one plan group by UUID.
-//
 func (api API) DeletePlanGroup(planGroupUUID string) error {
 	return api.delete(singlePlanGroupEndpoint, planGroupUUID)
 }

--- a/plans.go
+++ b/plans.go
@@ -31,21 +31,18 @@ type ListPlansParams struct {
 }
 
 // CreatePlan creates plan under given Data Source.
-//
 func (api API) CreatePlan(plan *Plan) (result *Plan, err error) {
 	result = &Plan{}
 	return result, api.create(plansEndpoint, plan, result)
 }
 
 // RetrievePlan returns one plan by UUID.
-//
 func (api API) RetrievePlan(planUUID string) (*Plan, error) {
 	result := &Plan{}
 	return result, api.retrieve(singlePlanEndpoint, planUUID, result)
 }
 
 // ListPlans returns list of plans.
-//
 func (api API) ListPlans(listPlansParams *ListPlansParams) (*Plans, error) {
 	result := &Plans{}
 	query := make([]interface{}, 0, 1)
@@ -56,14 +53,12 @@ func (api API) ListPlans(listPlansParams *ListPlansParams) (*Plans, error) {
 }
 
 // UpdatePlan returns list of plans.
-//
 func (api API) UpdatePlan(plan *Plan, planUUID string) (*Plan, error) {
 	result := &Plan{}
 	return result, api.update(singlePlanEndpoint, planUUID, plan, result)
 }
 
 // DeletePlan deletes one plan by UUID.
-//
 func (api API) DeletePlan(planUUID string) error {
 	return api.delete(singlePlanEndpoint, planUUID)
 }

--- a/plans.go
+++ b/plans.go
@@ -32,7 +32,6 @@ type ListPlansParams struct {
 
 // CreatePlan creates plan under given Data Source.
 //
-// See https://dev.chartmogul.com/reference/plans
 func (api API) CreatePlan(plan *Plan) (result *Plan, err error) {
 	result = &Plan{}
 	return result, api.create(plansEndpoint, plan, result)
@@ -40,7 +39,6 @@ func (api API) CreatePlan(plan *Plan) (result *Plan, err error) {
 
 // RetrievePlan returns one plan by UUID.
 //
-// See https://dev.chartmogul.com/reference/plans
 func (api API) RetrievePlan(planUUID string) (*Plan, error) {
 	result := &Plan{}
 	return result, api.retrieve(singlePlanEndpoint, planUUID, result)
@@ -48,7 +46,6 @@ func (api API) RetrievePlan(planUUID string) (*Plan, error) {
 
 // ListPlans returns list of plans.
 //
-// See https://dev.chartmogul.com/reference/plans
 func (api API) ListPlans(listPlansParams *ListPlansParams) (*Plans, error) {
 	result := &Plans{}
 	query := make([]interface{}, 0, 1)
@@ -60,7 +57,6 @@ func (api API) ListPlans(listPlansParams *ListPlansParams) (*Plans, error) {
 
 // UpdatePlan returns list of plans.
 //
-// See https://dev.chartmogul.com/reference/plans
 func (api API) UpdatePlan(plan *Plan, planUUID string) (*Plan, error) {
 	result := &Plan{}
 	return result, api.update(singlePlanEndpoint, planUUID, plan, result)
@@ -68,7 +64,6 @@ func (api API) UpdatePlan(plan *Plan, planUUID string) (*Plan, error) {
 
 // DeletePlan deletes one plan by UUID.
 //
-// See https://dev.chartmogul.com/reference/plans
 func (api API) DeletePlan(planUUID string) error {
 	return api.delete(singlePlanEndpoint, planUUID)
 }

--- a/plans.go
+++ b/plans.go
@@ -32,7 +32,7 @@ type ListPlansParams struct {
 
 // CreatePlan creates plan under given Data Source.
 //
-// See https://dev.chartmogul.com/v1.0/reference#plans
+// See https://dev.chartmogul.com/reference/plans
 func (api API) CreatePlan(plan *Plan) (result *Plan, err error) {
 	result = &Plan{}
 	return result, api.create(plansEndpoint, plan, result)
@@ -40,7 +40,7 @@ func (api API) CreatePlan(plan *Plan) (result *Plan, err error) {
 
 // RetrievePlan returns one plan by UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#plans
+// See https://dev.chartmogul.com/reference/plans
 func (api API) RetrievePlan(planUUID string) (*Plan, error) {
 	result := &Plan{}
 	return result, api.retrieve(singlePlanEndpoint, planUUID, result)
@@ -48,7 +48,7 @@ func (api API) RetrievePlan(planUUID string) (*Plan, error) {
 
 // ListPlans returns list of plans.
 //
-// See https://dev.chartmogul.com/v1.0/reference#plans
+// See https://dev.chartmogul.com/reference/plans
 func (api API) ListPlans(listPlansParams *ListPlansParams) (*Plans, error) {
 	result := &Plans{}
 	query := make([]interface{}, 0, 1)
@@ -60,7 +60,7 @@ func (api API) ListPlans(listPlansParams *ListPlansParams) (*Plans, error) {
 
 // UpdatePlan returns list of plans.
 //
-// See https://dev.chartmogul.com/v1.0/reference#plans
+// See https://dev.chartmogul.com/reference/plans
 func (api API) UpdatePlan(plan *Plan, planUUID string) (*Plan, error) {
 	result := &Plan{}
 	return result, api.update(singlePlanEndpoint, planUUID, plan, result)
@@ -68,7 +68,7 @@ func (api API) UpdatePlan(plan *Plan, planUUID string) (*Plan, error) {
 
 // DeletePlan deletes one plan by UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#plans
+// See https://dev.chartmogul.com/reference/plans
 func (api API) DeletePlan(planUUID string) error {
 	return api.delete(singlePlanEndpoint, planUUID)
 }

--- a/subscription_events.go
+++ b/subscription_events.go
@@ -1,6 +1,26 @@
 package chartmogul
 
-const subscriptionEventsEndpoint = "subscription_events"
+import "strings"
+
+const (
+	subscriptionEventsEndpoint              = "subscription_events"
+	subscriptionEventDisabledStateEndpoint  = "subscription_events/:id/disabled_state"
+	subscriptionEventDisabledStateByExtEndpoint = "subscription_events/disabled_state"
+)
+
+// ToggleSubscriptionEventDisabledParams holds the parameters for toggling disabled state.
+type ToggleSubscriptionEventDisabledParams struct {
+	Disabled bool `json:"disabled"`
+}
+
+// ToggleSubscriptionEventDisabledByExternalIDParams holds parameters for toggling disabled state by external ID.
+type ToggleSubscriptionEventDisabledByExternalIDParams struct {
+	SubscriptionEvent struct {
+		DataSourceUUID string `json:"data_source_uuid"`
+		ExternalID     string `json:"external_id"`
+	} `json:"subscription_event"`
+	Disabled bool `json:"disabled"`
+}
 
 type SubscriptionEvent struct {
 	ID                        uint64      `json:"id,omitempty"`
@@ -22,6 +42,8 @@ type SubscriptionEvent struct {
 	TaxAmountInCents          int32       `json:"tax_amount_in_cents,omitempty"`
 	RetractedEventId          string      `json:"retracted_event_id,omitempty"`
 	EventOrder                int32       `json:"event_order,omitempty"`
+	Disabled                  *bool       `json:"disabled,omitempty"`
+	DisabledAt                string      `json:"disabled_at,omitempty"`
 }
 
 type SubscriptionEvents struct {
@@ -82,4 +104,17 @@ func (api API) DeleteSubscriptionEvent(deleteParams *DeleteSubscriptionEvent) er
 		subscriptionEventsEndpoint,
 		DeleteSubscriptionEventParams{Params: deleteParams},
 	)
+}
+
+// ToggleSubscriptionEventDisabled toggles the disabled state of a subscription event by ID.
+func (api API) ToggleSubscriptionEventDisabled(id string, params *ToggleSubscriptionEventDisabledParams) (*SubscriptionEvent, error) {
+	result := &SubscriptionEvent{}
+	path := strings.Replace(subscriptionEventDisabledStateEndpoint, ":id", id, 1)
+	return result, api.update(path, "", params, result)
+}
+
+// ToggleSubscriptionEventDisabledByExternalID toggles the disabled state of a subscription event by external ID and data source UUID.
+func (api API) ToggleSubscriptionEventDisabledByExternalID(params *ToggleSubscriptionEventDisabledByExternalIDParams) (*SubscriptionEvent, error) {
+	result := &SubscriptionEvent{}
+	return result, api.update(subscriptionEventDisabledStateByExtEndpoint, "", params, result)
 }

--- a/subscription_events.go
+++ b/subscription_events.go
@@ -3,8 +3,8 @@ package chartmogul
 import "strings"
 
 const (
-	subscriptionEventsEndpoint              = "subscription_events"
-	subscriptionEventDisabledStateEndpoint  = "subscription_events/:id/disabled_state"
+	subscriptionEventsEndpoint                  = "subscription_events"
+	subscriptionEventDisabledStateEndpoint      = "subscription_events/:id/disabled_state"
 	subscriptionEventDisabledStateByExtEndpoint = "subscription_events/disabled_state"
 )
 

--- a/subscription_events_test.go
+++ b/subscription_events_test.go
@@ -1,7 +1,10 @@
 package chartmogul
 
 import (
+	"io/ioutil"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -279,5 +282,104 @@ func TestUpdateSubscriptionEventUsingExternalIdAndDataSourceUuid(t *testing.T) {
 
 	if updatedSubEvent.Currency != "CNY" {
 		t.Errorf("Subscription Event's currency was not updated - expected: %v, actual: %v", "CNY", updatedSubEvent.Currency)
+	}
+}
+
+func TestToggleSubscriptionEventDisabled(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "PATCH"
+				if r.Method != expectedMethod {
+					t.Errorf("Requested method expected: %v, actual: %v", expectedMethod, r.Method)
+				}
+				expected := "/v/subscription_events/12345/disabled_state"
+				path := r.URL.Path
+				if path != expected {
+					t.Errorf("Requested path expected: %v, actual: %v", expected, path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+				defer r.Body.Close()
+				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal("error should be nil")
+				}
+				expectedBody := `{"disabled":true}`
+				if string(body) != expectedBody {
+					t.Errorf("Requested body expected: %v, actual: %v", expectedBody, string(body))
+				}
+				w.Write([]byte(`{"id":12345,"disabled":true,"disabled_at":"2026-03-17T10:00:00Z"}`)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	result, err := tested.ToggleSubscriptionEventDisabled("12345", &ToggleSubscriptionEventDisabledParams{
+		Disabled: true,
+	})
+
+	if err != nil {
+		t.Fatalf("Not expected to fail: %v", err)
+	}
+	if result.ID != 12345 {
+		t.Errorf("Expected ID 12345, got: %v", result.ID)
+	}
+	if result.Disabled == nil || *result.Disabled != true {
+		t.Error("Expected disabled to be true")
+	}
+	if result.DisabledAt != "2026-03-17T10:00:00Z" {
+		t.Errorf("Expected disabled_at, got: %v", result.DisabledAt)
+	}
+}
+
+func TestToggleSubscriptionEventDisabledByExternalID(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "PATCH"
+				if r.Method != expectedMethod {
+					t.Errorf("Requested method expected: %v, actual: %v", expectedMethod, r.Method)
+				}
+				expected := "/v/subscription_events/disabled_state"
+				path := r.URL.Path
+				if path != expected {
+					t.Errorf("Requested path expected: %v, actual: %v", expected, path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+				defer r.Body.Close()
+				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal("error should be nil")
+				}
+				// Verify the body contains the expected structure
+				if len(body) == 0 {
+					t.Fatal("Expected non-empty body")
+				}
+				w.Write([]byte(`{"id":67890,"external_id":"evt_ext_1","data_source_uuid":"ds_abc","disabled":false}`)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	params := &ToggleSubscriptionEventDisabledByExternalIDParams{
+		Disabled: false,
+	}
+	params.SubscriptionEvent.DataSourceUUID = "ds_abc"
+	params.SubscriptionEvent.ExternalID = "evt_ext_1"
+
+	result, err := tested.ToggleSubscriptionEventDisabledByExternalID(params)
+
+	if err != nil {
+		t.Fatalf("Not expected to fail: %v", err)
+	}
+	if result.ID != 67890 {
+		t.Errorf("Expected ID 67890, got: %v", result.ID)
+	}
+	if result.Disabled == nil || *result.Disabled != false {
+		t.Error("Expected disabled to be false")
 	}
 }

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -36,7 +36,7 @@ type CancelSubscriptionParams struct {
 
 // CancelSubscription creates an Import API Data Source in ChartMogul.
 //
-// See https://dev.chartmogul.com/v1.0/reference#subscriptions
+// See https://dev.chartmogul.com/reference/subscriptions
 func (api API) CancelSubscription(subscriptionUUID string, cancelSubscriptionParams *CancelSubscriptionParams) (*Subscription, error) {
 	result := &Subscription{}
 	return result, api.update(cancelSubscriptionEndpoint,

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -36,7 +36,6 @@ type CancelSubscriptionParams struct {
 
 // CancelSubscription creates an Import API Data Source in ChartMogul.
 //
-// See https://dev.chartmogul.com/reference/subscriptions
 func (api API) CancelSubscription(subscriptionUUID string, cancelSubscriptionParams *CancelSubscriptionParams) (*Subscription, error) {
 	result := &Subscription{}
 	return result, api.update(cancelSubscriptionEndpoint,

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -35,7 +35,6 @@ type CancelSubscriptionParams struct {
 }
 
 // CancelSubscription creates an Import API Data Source in ChartMogul.
-//
 func (api API) CancelSubscription(subscriptionUUID string, cancelSubscriptionParams *CancelSubscriptionParams) (*Subscription, error) {
 	result := &Subscription{}
 	return result, api.update(cancelSubscriptionEndpoint,

--- a/tags.go
+++ b/tags.go
@@ -18,7 +18,6 @@ const (
 
 // AddTagsToCustomer gives customer new tags.
 //
-// See https://dev.chartmogul.com/reference/tags
 func (api API) AddTagsToCustomer(customerUUID string, tags []string) (*TagsResult, error) {
 	output := &TagsResult{}
 	err := api.add(customerTagsEndpoint,
@@ -31,7 +30,6 @@ func (api API) AddTagsToCustomer(customerUUID string, tags []string) (*TagsResul
 // AddTagsToCustomersWithEmail gives new tags to (multiple) customers
 // identified by e-mail only.
 //
-// See https://dev.chartmogul.com/reference/tags
 func (api API) AddTagsToCustomersWithEmail(email string, tags []string) (*Customers, error) {
 	output := &Customers{}
 	err := api.create(tagsEndpoint,
@@ -42,7 +40,6 @@ func (api API) AddTagsToCustomersWithEmail(email string, tags []string) (*Custom
 
 // RemoveTagsFromCustomer deletes passed tags from customer of given UUID.
 //
-// See https://dev.chartmogul.com/reference/tags
 func (api API) RemoveTagsFromCustomer(customerUUID string, tags []string) (*TagsResult, error) {
 	output := &TagsResult{}
 	err := api.deleteWhat(customerTagsEndpoint,

--- a/tags.go
+++ b/tags.go
@@ -17,7 +17,6 @@ const (
 )
 
 // AddTagsToCustomer gives customer new tags.
-//
 func (api API) AddTagsToCustomer(customerUUID string, tags []string) (*TagsResult, error) {
 	output := &TagsResult{}
 	err := api.add(customerTagsEndpoint,
@@ -29,7 +28,6 @@ func (api API) AddTagsToCustomer(customerUUID string, tags []string) (*TagsResul
 
 // AddTagsToCustomersWithEmail gives new tags to (multiple) customers
 // identified by e-mail only.
-//
 func (api API) AddTagsToCustomersWithEmail(email string, tags []string) (*Customers, error) {
 	output := &Customers{}
 	err := api.create(tagsEndpoint,
@@ -39,7 +37,6 @@ func (api API) AddTagsToCustomersWithEmail(email string, tags []string) (*Custom
 }
 
 // RemoveTagsFromCustomer deletes passed tags from customer of given UUID.
-//
 func (api API) RemoveTagsFromCustomer(customerUUID string, tags []string) (*TagsResult, error) {
 	output := &TagsResult{}
 	err := api.deleteWhat(customerTagsEndpoint,

--- a/tags.go
+++ b/tags.go
@@ -18,7 +18,7 @@ const (
 
 // AddTagsToCustomer gives customer new tags.
 //
-// See https://dev.chartmogul.com/v1.0/reference#tags
+// See https://dev.chartmogul.com/reference/tags
 func (api API) AddTagsToCustomer(customerUUID string, tags []string) (*TagsResult, error) {
 	output := &TagsResult{}
 	err := api.add(customerTagsEndpoint,
@@ -31,7 +31,7 @@ func (api API) AddTagsToCustomer(customerUUID string, tags []string) (*TagsResul
 // AddTagsToCustomersWithEmail gives new tags to (multiple) customers
 // identified by e-mail only.
 //
-// See https://dev.chartmogul.com/v1.0/reference#tags
+// See https://dev.chartmogul.com/reference/tags
 func (api API) AddTagsToCustomersWithEmail(email string, tags []string) (*Customers, error) {
 	output := &Customers{}
 	err := api.create(tagsEndpoint,
@@ -42,7 +42,7 @@ func (api API) AddTagsToCustomersWithEmail(email string, tags []string) (*Custom
 
 // RemoveTagsFromCustomer deletes passed tags from customer of given UUID.
 //
-// See https://dev.chartmogul.com/v1.0/reference#tags
+// See https://dev.chartmogul.com/reference/tags
 func (api API) RemoveTagsFromCustomer(customerUUID string, tags []string) (*TagsResult, error) {
 	output := &TagsResult{}
 	err := api.deleteWhat(customerTagsEndpoint,

--- a/tasks.go
+++ b/tasks.go
@@ -52,7 +52,6 @@ const (
 
 // CreateTask creates the task through the API.
 //
-// See https://dev.chartmogul.com/reference/create-a-task
 func (api API) CreateTask(input *NewTask) (*Task, error) {
 	result := &Task{}
 	return result, api.create(tasksEndpoint, input, result)
@@ -60,7 +59,6 @@ func (api API) CreateTask(input *NewTask) (*Task, error) {
 
 // RetrieveTask returns one task from the API.
 //
-// See https://dev.chartmogul.com/reference/retrieve-a-task
 func (api API) RetrieveTask(taskUUID string) (*Task, error) {
 	result := &Task{}
 	return result, api.retrieve(singleTaskEndpoint, taskUUID, result)
@@ -68,7 +66,6 @@ func (api API) RetrieveTask(taskUUID string) (*Task, error) {
 
 // UpdateTask updates one task through the API.
 //
-// See https://dev.chartmogul.com/reference/update-a-task
 func (api API) UpdateTask(input *UpdateTask, taskUUID string) (*Task, error) {
 	output := &Task{}
 	return output, api.update(singleTaskEndpoint, taskUUID, input, output)
@@ -76,7 +73,6 @@ func (api API) UpdateTask(input *UpdateTask, taskUUID string) (*Task, error) {
 
 // ListTasks lists all tasks.
 //
-// See https://dev.chartmogul.com/reference/list-tasks
 func (api API) ListTasks(listTasksParams *ListTasksParams) (*Tasks, error) {
 	result := &Tasks{}
 	query := make([]interface{}, 0, 1)
@@ -88,7 +84,6 @@ func (api API) ListTasks(listTasksParams *ListTasksParams) (*Tasks, error) {
 
 // DeleteTask deletes one task by UUID.
 //
-// See https://dev.chartmogul.com/reference/delete-a-task
 func (api API) DeleteTask(taskUUID string) error {
 	return api.delete(singleTaskEndpoint, taskUUID)
 }

--- a/tasks.go
+++ b/tasks.go
@@ -51,28 +51,24 @@ const (
 )
 
 // CreateTask creates the task through the API.
-//
 func (api API) CreateTask(input *NewTask) (*Task, error) {
 	result := &Task{}
 	return result, api.create(tasksEndpoint, input, result)
 }
 
 // RetrieveTask returns one task from the API.
-//
 func (api API) RetrieveTask(taskUUID string) (*Task, error) {
 	result := &Task{}
 	return result, api.retrieve(singleTaskEndpoint, taskUUID, result)
 }
 
 // UpdateTask updates one task through the API.
-//
 func (api API) UpdateTask(input *UpdateTask, taskUUID string) (*Task, error) {
 	output := &Task{}
 	return output, api.update(singleTaskEndpoint, taskUUID, input, output)
 }
 
 // ListTasks lists all tasks.
-//
 func (api API) ListTasks(listTasksParams *ListTasksParams) (*Tasks, error) {
 	result := &Tasks{}
 	query := make([]interface{}, 0, 1)
@@ -83,7 +79,6 @@ func (api API) ListTasks(listTasksParams *ListTasksParams) (*Tasks, error) {
 }
 
 // DeleteTask deletes one task by UUID.
-//
 func (api API) DeleteTask(taskUUID string) error {
 	return api.delete(singleTaskEndpoint, taskUUID)
 }

--- a/transactions.go
+++ b/transactions.go
@@ -19,7 +19,6 @@ type Transaction struct {
 // CreateTransaction loads an transaction to a customer in Chartmogul.
 // Customer must have a valid UUID! (use return value of API)
 //
-// See https://dev.chartmogul.com/reference/transactions
 func (api API) CreateTransaction(transaction *Transaction, invoiceUUID string) (*Transaction, error) {
 	result := &Transaction{}
 	path := strings.Replace(transactionsEndpoint, ":invoiceUUID", invoiceUUID, 1)

--- a/transactions.go
+++ b/transactions.go
@@ -19,7 +19,7 @@ type Transaction struct {
 // CreateTransaction loads an transaction to a customer in Chartmogul.
 // Customer must have a valid UUID! (use return value of API)
 //
-// See https://dev.chartmogul.com/v1.0/reference#transactions
+// See https://dev.chartmogul.com/reference/transactions
 func (api API) CreateTransaction(transaction *Transaction, invoiceUUID string) (*Transaction, error) {
 	result := &Transaction{}
 	path := strings.Replace(transactionsEndpoint, ":invoiceUUID", invoiceUUID, 1)

--- a/transactions.go
+++ b/transactions.go
@@ -18,7 +18,6 @@ type Transaction struct {
 
 // CreateTransaction loads an transaction to a customer in Chartmogul.
 // Customer must have a valid UUID! (use return value of API)
-//
 func (api API) CreateTransaction(transaction *Transaction, invoiceUUID string) (*Transaction, error) {
 	result := &Transaction{}
 	path := strings.Replace(transactionsEndpoint, ":invoiceUUID", invoiceUUID, 1)


### PR DESCRIPTION
## Summary

Backport of new features from the v5 branch (#83) that are backwards-compatible with v4 consumers.

- Add Invoice update-status and disable-toggle endpoints (`UpdateInvoiceStatus`, `ToggleInvoiceDisabled`)
- Add SubscriptionEvent disable-state toggling (`ToggleSubscriptionEventDisabled`, `ToggleSubscriptionEventDisabledByExternalID`)
- Add Account `ID` field and `include` query parameter support for `RetrieveAccount`
- Add `Errors` field to `LineItem` struct
- Add `DisabledAt` field to `Invoice` struct
- Make retry behavior configurable via `API.Retry` (`RetryConfig`)
- URL-encode `include` query parameter in `RetrieveAccount`
- Remove outdated API docs link comments from all source files
- Update `IApi` interface and regenerate mocks

## ⚠️ Backwards compatibility review

### ✅ Fully non-breaking for callers

All changes are additive for consumers calling the SDK:
- **New struct fields** (`Account.ID`, `LineItem.Errors`, `Invoice.DisabledAt`, etc.) — existing code ignores them
- **New methods** (`UpdateInvoiceStatus`, `ToggleInvoiceDisabled`, `ToggleSubscriptionEventDisabled`, `ToggleSubscriptionEventDisabledByExternalID`) — additive, no existing methods changed
- **New `RetryConfig` type and `API.Retry` field** — zero-value (`nil`) preserves existing retry-enabled behavior
- **`RetrieveAccount` variadic params** — existing `api.RetrieveAccount()` calls continue to work with no changes

### ⚠️ Breaking for `IApi` interface implementors only

If you have a custom type that implements `IApi`, you will need to add:
- `UpdateInvoiceStatus(dataSourceUUID, invoiceExternalID string, params *UpdateInvoiceStatusParams) error`
- `ToggleInvoiceDisabled(invoiceUUID string, params *ToggleInvoiceDisabledParams) (*Invoice, error)`
- `ToggleSubscriptionEventDisabled(id string, params *ToggleSubscriptionEventDisabledParams) (*SubscriptionEvent, error)`
- `ToggleSubscriptionEventDisabledByExternalID(params *ToggleSubscriptionEventDisabledByExternalIDParams) (*SubscriptionEvent, error)`
- Update `RetrieveAccount()` → `RetrieveAccount(params ...*RetrieveAccountParams)`

Most users only use `*API` directly and will not be affected.

### ❌ Intentionally excluded (v5 only)

The following breaking changes are NOT included and will ship in v5:
- Auth restructure (`AccountToken`/`AccessKey` → `ApiKey`)
- Pagination model change (page-based → cursor-based)
- `Invoice.Errors` type change (`*Errors` → `*InvoiceErrors`)
- `RetryConfig.Enabled` type change (`bool` → `*bool`)
- `ToggleSubscriptionEventDisabled` id type change (`string` → `uint64`)
- Struct field type tightening (`interface{}` → `map[string]interface{}`)
- Removal of `EmptyDataSource` and `PurgeDataSource`

## Test plan
- [x] All unit tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] `gofmt` clean
- [x] Manual testing against ChartMogul API (13/13 passed)

## Testing instructions

> Test against the **WiktorOnboarding** account (`acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`).
> Impersonate `wiktor@chartmogul.com` to find the API key, then:
> ```bash
> export CHARTMOGUL_API_KEY='<api_key>'
> ```
> The test file is at `sdks/tests/go/test_pip_310_v4.go`. It creates its own test data (data source, plan, customer, invoice), uses an existing Stripe invoice for the toggle test, and cleans up on exit. Run with:
> ```bash
> cd sdks/tests/go && go run test_pip_310_v4.go
> ```

### RetrieveAccount (no params)

```go
account, err := api.RetrieveAccount()
// Verify: account.Name, account.Currency populated, account.ID non-empty
```

### RetrieveAccount (with include)

```go
account, err := api.RetrieveAccount(&cm.RetrieveAccountParams{
    Include: "churn_recognition,churn_when_zero_mrr",
})
// Verify: account.ChurnRecognition and account.ChurnWhenZeroMRR are non-nil
```

### Account ID field

```go
account, err := api.RetrieveAccount()
// Verify: account.ID is non-empty (e.g. "acc_d0ea225e-...")
```

### RetryConfig (bool in v4)

```go
apiRetry := cm.API{
    ApiKey: apiKey,
    Retry: &cm.RetryConfig{Enabled: true, MaxElapsedTime: 30 * time.Second},
}
// Verify: normal calls succeed

apiNoRetry := cm.API{
    ApiKey: apiKey,
    Retry:  &cm.RetryConfig{Enabled: false},
}
// Verify: normal calls succeed, but 429s are NOT retried
```

### LineItem Errors field

```go
// After creating an invoice:
li := invoice.LineItems[0]
fmt.Println(li.Errors)  // nil for valid items, populated for invalid ones
```

### ToggleInvoiceDisabled

```go
// Requires a Stripe invoice (custom DS not supported)
disabled, err := api.ToggleInvoiceDisabled(invoiceUUID, &cm.ToggleInvoiceDisabledParams{Disabled: true})
// Verify: disabled.DisabledAt is non-empty

enabled, err := api.ToggleInvoiceDisabled(invoiceUUID, &cm.ToggleInvoiceDisabledParams{Disabled: false})
// Verify: enabled.DisabledAt is empty
```

### UpdateInvoiceStatus

```go
err := api.UpdateInvoiceStatus(dsUUID, "pip310_inv_1", &cm.UpdateInvoiceStatusParams{Status: "voided"})
// Verify: no error
```

### ToggleSubscriptionEventDisabled (by ID, string in v4)

```go
evtID := fmt.Sprintf("%d", subEvt.ID)  // v4: string
toggled, err := api.ToggleSubscriptionEventDisabled(evtID, &cm.ToggleSubscriptionEventDisabledParams{Disabled: true})
// Verify: *toggled.Disabled == true, toggled.DisabledAt non-empty

toggled, err = api.ToggleSubscriptionEventDisabled(evtID, &cm.ToggleSubscriptionEventDisabledParams{Disabled: false})
// Verify: *toggled.Disabled == false
```

### ToggleSubscriptionEventDisabledByExternalID

```go
params := &cm.ToggleSubscriptionEventDisabledByExternalIDParams{Disabled: true}
params.SubscriptionEvent.DataSourceUUID = dsUUID
params.SubscriptionEvent.ExternalID = extID

toggled, err := api.ToggleSubscriptionEventDisabledByExternalID(params)
// Verify: *toggled.Disabled == true

params.Disabled = false
toggled, err = api.ToggleSubscriptionEventDisabledByExternalID(params)
// Verify: *toggled.Disabled == false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)