### PR TITLE
Add immutable release enforcement and security docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        with:
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 |
 <b><a href="#contributing">Contributing</a></b>
 |
+<b><a href="#security">Security</a></b>
+|
 <b><a href="#license">License</a></b>
 </p>
 <hr>
@@ -31,11 +33,15 @@
 
 ## Installation
 
-This library requires Go 1.11 or above.
+This library requires Go 1.21 or above.
 
 ```sh
-go get github.com/chartmogul/chartmogul-go/v4
+go get github.com/chartmogul/chartmogul-go/v4@v4.11.0
 ```
+
+We recommend pinning to a specific version as shown above. Go modules will record the exact version and cryptographic checksums in your `go.mod` and `go.sum` files.
+
+Always commit your `go.sum` file to version control. It contains cryptographic hashes verified against the [Go checksum database](https://sum.golang.org), ensuring the code you depend on has not been tampered with.
 
 ## Configuration
 [Deprecation] - `account_token`/`secret_key` combo is deprecated. Please use API key for both fields.
@@ -369,6 +375,19 @@ To work on the library:
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/chartmogul/chartmogul-go.
+
+## Security
+
+### Verifying Releases
+
+All releases of this library are published as [immutable GitHub Releases](https://github.com/chartmogul/chartmogul-go/releases) with protected tags.
+
+When you install this library via `go get`, Go automatically verifies the module contents against the [Go checksum database](https://sum.golang.org). This ensures that the code you download matches what was originally published and has not been modified.
+
+To maximize supply chain security:
+- **Pin to a specific version**: `go get github.com/chartmogul/chartmogul-go/v4@v4.11.0`
+- **Commit your `go.sum`** file to version control
+- **Do not disable** `GONOSUMCHECK` or `GONOSUMDB` for this module
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,65 @@
+# Releasing chartmogul-go
+
+## Prerequisites
+
+- You must have push access to the repository
+- Tags matching `v*` are protected by GitHub tag protection rulesets
+- Releases are immutable once published (GitHub repository setting)
+
+## Release Process
+
+1. Ensure all changes are merged to the `v4` branch
+2. Ensure CI is green on the `v4` branch
+3. Create and push a version tag:
+   ```sh
+   git tag v4.X.Y
+   git push origin v4.X.Y
+   ```
+4. The [release workflow](.github/workflows/release.yml) will automatically create a GitHub Release with auto-generated release notes
+5. Verify the release appears at https://github.com/chartmogul/chartmogul-go/releases
+6. The Go module proxy (proxy.golang.org) will cache the new version on first fetch
+
+## Changelog
+
+Release notes are auto-generated from merged PR titles by the [release workflow](.github/workflows/release.yml). To ensure useful changelogs:
+
+- Use clear, descriptive PR titles (e.g., "Add External ID field to Contact model")
+- Prefix breaking changes with `BREAKING:` so they stand out in release notes
+- After the release is created, review and edit the notes on the [Releases page](https://github.com/chartmogul/chartmogul-go/releases) if needed
+
+## Pre-release Versions
+
+For pre-release versions, use a semver pre-release suffix:
+
+```sh
+git tag v4.X.Y-rc1
+git push origin v4.X.Y-rc1
+```
+
+These will be automatically marked as pre-releases on GitHub.
+
+## Security
+
+### Repository Protections
+
+- **Immutable releases**: Once a GitHub Release is published, its tag cannot be moved or deleted, and release assets cannot be modified
+- **Tag protection rulesets**: `v*` tags cannot be deleted or force-pushed
+
+### Go Module Proxy
+
+- [proxy.golang.org](https://proxy.golang.org) caches module versions permanently on first fetch
+- [sum.golang.org](https://sum.golang.org) records cryptographic hashes in a tamper-evident Merkle tree
+- Users running `go get` with default settings automatically verify against both services
+
+### What This Protects Against
+
+- A compromised maintainer account cannot modify or delete existing releases
+- Tags cannot be moved to point to different commits after publication
+- The Go checksum database provides an independent verification layer beyond GitHub
+
+### Repository Settings (Admin)
+
+These settings must be configured by a repository admin:
+
+1. **Immutable Releases**: Settings > General > Releases > Enable "Immutable releases"
+2. **Tag Protection Ruleset**: Settings > Rules > Rulesets > New ruleset targeting tags matching `v*` with deletion and force-push prevention


### PR DESCRIPTION
## Summary

- Add release workflow (`.github/workflows/release.yml`) that auto-creates GitHub Releases on `v*` tag push with auto-generated release notes
- Update README installation to recommend pinned versions (`@v4.11.0`), bump minimum Go to 1.21, add Security section explaining checksum verification
- Add `RELEASING.md` documenting the release process, changelog conventions, and security protections

Closes https://linear.app/chartmogul/issue/OME-528

## Admin steps required

After merging, a repository admin should:

1. **Enable Immutable Releases**: Settings → General → Releases → Enable "Immutable releases"
2. **Add Tag Protection Ruleset**: Settings → Rules → Rulesets → New ruleset targeting tags matching `v*` with deletion and force-push prevention

## Test plan

- [x] Verify `release.yml` passes zizmor linting on this PR
- [ ] After merging + enabling immutable releases, push a test tag (e.g., `v4.12.0-rc1`) and confirm a GitHub Release is created automatically
- [ ] Confirm the release is marked as pre-release and has auto-generated notes
- [ ] Verify the release tag cannot be deleted after enabling immutable releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)