### PR TITLE
Add transaction retrieve, update, toggle disabled, and delete endpoints

### DIFF
--- a/chartmogul.go
+++ b/chartmogul.go
@@ -92,6 +92,10 @@ type IApi interface {
 	DisconnectSubscriptions(customerUUID string, subscriptions []Subscription) error
 	// Transactions
 	CreateTransaction(transaction *Transaction, invoiceUUID string) (*Transaction, error)
+	RetrieveTransaction(transactionUUID string, params ...*RetrieveTransactionParams) (*Transaction, error)
+	UpdateTransaction(transactionUUID string, params *UpdateTransactionParams) (*Transaction, error)
+	ToggleTransactionDisabled(transactionUUID string, params *ToggleTransactionDisabledParams) (*Transaction, error)
+	DeleteTransaction(transactionUUID string) error
 
 	// Customers
 	CreateCustomer(newCustomer *NewCustomer) (*Customer, error)

--- a/mock_chartmogul/chartmogul.go
+++ b/mock_chartmogul/chartmogul.go
@@ -515,6 +515,20 @@ func (mr *MockIApiMockRecorder) DeleteTask(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTask", reflect.TypeOf((*MockIApi)(nil).DeleteTask), arg0)
 }
 
+// DeleteTransaction mocks base method
+func (m *MockIApi) DeleteTransaction(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTransaction", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTransaction indicates an expected call of DeleteTransaction
+func (mr *MockIApiMockRecorder) DeleteTransaction(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransaction", reflect.TypeOf((*MockIApi)(nil).DeleteTransaction), arg0)
+}
+
 // DisconnectSubscriptions mocks base method
 func (m *MockIApi) DisconnectSubscriptions(arg0 string, arg1 []chartmogul.Subscription) error {
 	m.ctrl.T.Helper()
@@ -1297,6 +1311,26 @@ func (mr *MockIApiMockRecorder) RetrieveTask(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveTask", reflect.TypeOf((*MockIApi)(nil).RetrieveTask), arg0)
 }
 
+// RetrieveTransaction mocks base method
+func (m *MockIApi) RetrieveTransaction(arg0 string, arg1 ...*chartmogul.RetrieveTransactionParams) (*chartmogul.Transaction, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RetrieveTransaction", varargs...)
+	ret0, _ := ret[0].(*chartmogul.Transaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RetrieveTransaction indicates an expected call of RetrieveTransaction
+func (mr *MockIApiMockRecorder) RetrieveTransaction(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveTransaction", reflect.TypeOf((*MockIApi)(nil).RetrieveTransaction), varargs...)
+}
+
 // SearchCustomers mocks base method
 func (m *MockIApi) SearchCustomers(arg0 *chartmogul.SearchCustomersParams) (*chartmogul.Customers, error) {
 	m.ctrl.T.Helper()
@@ -1370,6 +1404,21 @@ func (m *MockIApi) ToggleSubscriptionEventDisabledByExternalID(arg0 *chartmogul.
 func (mr *MockIApiMockRecorder) ToggleSubscriptionEventDisabledByExternalID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToggleSubscriptionEventDisabledByExternalID", reflect.TypeOf((*MockIApi)(nil).ToggleSubscriptionEventDisabledByExternalID), arg0)
+}
+
+// ToggleTransactionDisabled mocks base method
+func (m *MockIApi) ToggleTransactionDisabled(arg0 string, arg1 *chartmogul.ToggleTransactionDisabledParams) (*chartmogul.Transaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ToggleTransactionDisabled", arg0, arg1)
+	ret0, _ := ret[0].(*chartmogul.Transaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ToggleTransactionDisabled indicates an expected call of ToggleTransactionDisabled
+func (mr *MockIApiMockRecorder) ToggleTransactionDisabled(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToggleTransactionDisabled", reflect.TypeOf((*MockIApi)(nil).ToggleTransactionDisabled), arg0, arg1)
 }
 
 // UnmergeCustomers mocks base method
@@ -1548,4 +1597,19 @@ func (m *MockIApi) UpdateTask(arg0 *chartmogul.UpdateTask, arg1 string) (*chartm
 func (mr *MockIApiMockRecorder) UpdateTask(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTask", reflect.TypeOf((*MockIApi)(nil).UpdateTask), arg0, arg1)
+}
+
+// UpdateTransaction mocks base method
+func (m *MockIApi) UpdateTransaction(arg0 string, arg1 *chartmogul.UpdateTransactionParams) (*chartmogul.Transaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateTransaction", arg0, arg1)
+	ret0, _ := ret[0].(*chartmogul.Transaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateTransaction indicates an expected call of UpdateTransaction
+func (mr *MockIApiMockRecorder) UpdateTransaction(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTransaction", reflect.TypeOf((*MockIApi)(nil).UpdateTransaction), arg0, arg1)
 }

--- a/transactions.go
+++ b/transactions.go
@@ -10,20 +10,20 @@ const (
 
 // Transaction is either payment/refund on an invoice, for its full value.
 type Transaction struct {
-	UUID                   string              `json:"uuid,omitempty"`
-	Date                   string              `json:"date"`
-	ExternalID             string              `json:"external_id,omitempty"`
-	Result                 string              `json:"result"`
-	Type                   string              `json:"type"`
-	AmountInCents          *int                `json:"amount_in_cents,omitempty"`
-	TransactionFeesInCents *int                `json:"transaction_fees_in_cents,omitempty"`
-	TransactionFeesCurrency string             `json:"transaction_fees_currency,omitempty"`
-	Disabled               *bool               `json:"disabled,omitempty"`
-	DisabledAt             string              `json:"disabled_at,omitempty"`
-	DisabledBy             string              `json:"disabled_by,omitempty"`
-	UserCreated            *bool               `json:"user_created,omitempty"`
-	EditHistorySummary     *EditHistorySummary `json:"edit_history_summary,omitempty"`
-	Errors                 Errors              `json:"errors,omitempty"`
+	UUID                    string              `json:"uuid,omitempty"`
+	Date                    string              `json:"date"`
+	ExternalID              string              `json:"external_id,omitempty"`
+	Result                  string              `json:"result"`
+	Type                    string              `json:"type"`
+	AmountInCents           *int                `json:"amount_in_cents,omitempty"`
+	TransactionFeesInCents  *int                `json:"transaction_fees_in_cents,omitempty"`
+	TransactionFeesCurrency string              `json:"transaction_fees_currency,omitempty"`
+	Disabled                *bool               `json:"disabled,omitempty"`
+	DisabledAt              string              `json:"disabled_at,omitempty"`
+	DisabledBy              string              `json:"disabled_by,omitempty"`
+	UserCreated             *bool               `json:"user_created,omitempty"`
+	EditHistorySummary      *EditHistorySummary `json:"edit_history_summary,omitempty"`
+	Errors                  Errors              `json:"errors,omitempty"`
 }
 
 // RetrieveTransactionParams optional parameters for RetrieveTransaction.

--- a/transactions.go
+++ b/transactions.go
@@ -2,24 +2,81 @@ package chartmogul
 
 import "strings"
 
-const transactionsEndpoint = "import/invoices/:invoiceUUID/transactions"
+const (
+	transactionsEndpoint             = "import/invoices/:invoiceUUID/transactions"
+	singleTransactionEndpoint        = "transactions/:uuid"
+	transactionDisabledStateEndpoint = "transactions/:uuid/disabled_state"
+)
 
 // Transaction is either payment/refund on an invoice, for its full value.
 type Transaction struct {
-	UUID                   string `json:"uuid,omitempty"`
-	Date                   string `json:"date"`
-	ExternalID             string `json:"external_id,omitempty"`
-	Result                 string `json:"result"`
-	Type                   string `json:"type"`
-	AmountInCents          *int   `json:"amount_in_cents,omitempty"`
-	TransactionFeesInCents *int   `json:"transaction_fees_in_cents,omitempty"`
-	Errors                 Errors `json:"errors,omitempty"`
+	UUID                   string              `json:"uuid,omitempty"`
+	Date                   string              `json:"date"`
+	ExternalID             string              `json:"external_id,omitempty"`
+	Result                 string              `json:"result"`
+	Type                   string              `json:"type"`
+	AmountInCents          *int                `json:"amount_in_cents,omitempty"`
+	TransactionFeesInCents *int                `json:"transaction_fees_in_cents,omitempty"`
+	TransactionFeesCurrency string             `json:"transaction_fees_currency,omitempty"`
+	Disabled               *bool               `json:"disabled,omitempty"`
+	DisabledAt             string              `json:"disabled_at,omitempty"`
+	DisabledBy             string              `json:"disabled_by,omitempty"`
+	UserCreated            *bool               `json:"user_created,omitempty"`
+	EditHistorySummary     *EditHistorySummary `json:"edit_history_summary,omitempty"`
+	Errors                 Errors              `json:"errors,omitempty"`
 }
 
-// CreateTransaction loads an transaction to a customer in Chartmogul.
-// Customer must have a valid UUID! (use return value of API)
+// RetrieveTransactionParams optional parameters for RetrieveTransaction.
+type RetrieveTransactionParams struct {
+	ValidationType       string `json:"validation_type,omitempty"`
+	IncludeEditHistories *bool  `json:"include_edit_histories,omitempty"`
+	WithDisabled         *bool  `json:"with_disabled,omitempty"`
+}
+
+// UpdateTransactionParams holds the parameters for UpdateTransaction.
+type UpdateTransactionParams struct {
+	Type                    string `json:"type,omitempty"`
+	Date                    string `json:"date,omitempty"`
+	Result                  string `json:"result,omitempty"`
+	AmountInCents           *int   `json:"amount_in_cents,omitempty"`
+	TransactionFeesInCents  *int   `json:"transaction_fees_in_cents,omitempty"`
+	TransactionFeesCurrency string `json:"transaction_fees_currency,omitempty"`
+}
+
+// ToggleTransactionDisabledParams holds the parameters for ToggleTransactionDisabled.
+type ToggleTransactionDisabledParams struct {
+	Disabled bool `json:"disabled"`
+}
+
+// CreateTransaction loads a transaction to an invoice in Chartmogul.
 func (api API) CreateTransaction(transaction *Transaction, invoiceUUID string) (*Transaction, error) {
 	result := &Transaction{}
 	path := strings.Replace(transactionsEndpoint, ":invoiceUUID", invoiceUUID, 1)
 	return result, api.create(path, transaction, result)
+}
+
+// RetrieveTransaction returns one transaction by UUID.
+func (api API) RetrieveTransaction(transactionUUID string, params ...*RetrieveTransactionParams) (*Transaction, error) {
+	result := &Transaction{}
+	if len(params) > 0 && params[0] != nil {
+		return result, api.retrieveWithParams(singleTransactionEndpoint, transactionUUID, result, *params[0])
+	}
+	return result, api.retrieve(singleTransactionEndpoint, transactionUUID, result)
+}
+
+// UpdateTransaction updates a transaction by UUID.
+func (api API) UpdateTransaction(transactionUUID string, params *UpdateTransactionParams) (*Transaction, error) {
+	result := &Transaction{}
+	return result, api.update(singleTransactionEndpoint, transactionUUID, params, result)
+}
+
+// ToggleTransactionDisabled toggles the disabled state of a transaction.
+func (api API) ToggleTransactionDisabled(transactionUUID string, params *ToggleTransactionDisabledParams) (*Transaction, error) {
+	result := &Transaction{}
+	return result, api.update(transactionDisabledStateEndpoint, transactionUUID, params, result)
+}
+
+// DeleteTransaction deletes one transaction by UUID.
+func (api API) DeleteTransaction(transactionUUID string) error {
+	return api.delete(singleTransactionEndpoint, transactionUUID)
 }

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 const retrieveTransactionExample = `{
@@ -46,8 +44,7 @@ func TestRetrieveTransaction(t *testing.T) {
 	transaction, err := tested.RetrieveTransaction("tr_879d560a-1bec-41bb-986e-665e38a2f7bc")
 
 	if err != nil {
-		spew.Dump(err)
-		t.Fatal("Not expected to fail")
+		t.Fatal("Not expected to fail:", err)
 	}
 	if transaction.UUID != "tr_879d560a-1bec-41bb-986e-665e38a2f7bc" {
 		t.Errorf("Expected UUID tr_879d560a-1bec-41bb-986e-665e38a2f7bc, got: %v", transaction.UUID)
@@ -81,8 +78,7 @@ func TestRetrieveTransactionWithParams(t *testing.T) {
 	})
 
 	if err != nil {
-		spew.Dump(err)
-		t.Fatal("Not expected to fail")
+		t.Fatal("Not expected to fail:", err)
 	}
 	if transaction.UUID != "tr_879d560a-1bec-41bb-986e-665e38a2f7bc" {
 		t.Errorf("Expected UUID tr_879d560a-1bec-41bb-986e-665e38a2f7bc, got: %v", transaction.UUID)
@@ -126,8 +122,7 @@ func TestUpdateTransaction(t *testing.T) {
 	})
 
 	if err != nil {
-		spew.Dump(err)
-		t.Fatal("Not expected to fail")
+		t.Fatal("Not expected to fail:", err)
 	}
 	if transaction.UUID != "tr_123" {
 		t.Errorf("Expected UUID tr_123, got: %v", transaction.UUID)
@@ -173,8 +168,7 @@ func TestToggleTransactionDisabled(t *testing.T) {
 	})
 
 	if err != nil {
-		spew.Dump(err)
-		t.Fatal("Not expected to fail")
+		t.Fatal("Not expected to fail:", err)
 	}
 	if transaction.UUID != "tr_123" {
 		t.Errorf("Expected UUID tr_123, got: %v", transaction.UUID)
@@ -205,7 +199,6 @@ func TestDeleteTransaction(t *testing.T) {
 	err := tested.DeleteTransaction("tr_123")
 
 	if err != nil {
-		spew.Dump(err)
-		t.Fatal("Not expected to fail")
+		t.Fatal("Not expected to fail:", err)
 	}
 }

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -1,0 +1,211 @@
+package chartmogul
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+const retrieveTransactionExample = `{
+	"uuid": "tr_879d560a-1bec-41bb-986e-665e38a2f7bc",
+	"external_id": "tx_ext_123",
+	"type": "payment",
+	"date": "2015-11-05T00:14:23.000Z",
+	"result": "successful",
+	"disabled": false,
+	"disabled_at": "",
+	"disabled_by": "",
+	"user_created": false
+}`
+
+func TestRetrieveTransaction(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "GET"
+				if r.Method != expectedMethod {
+					t.Errorf("Requested method expected: %v, actual: %v", expectedMethod, r.Method)
+				}
+				expected := "/v/transactions/tr_879d560a-1bec-41bb-986e-665e38a2f7bc"
+				path := r.URL.Path
+				if path != expected {
+					t.Errorf("Requested path expected: %v, actual: %v", expected, path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+				w.Write([]byte(retrieveTransactionExample)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	transaction, err := tested.RetrieveTransaction("tr_879d560a-1bec-41bb-986e-665e38a2f7bc")
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if transaction.UUID != "tr_879d560a-1bec-41bb-986e-665e38a2f7bc" {
+		t.Errorf("Expected UUID tr_879d560a-1bec-41bb-986e-665e38a2f7bc, got: %v", transaction.UUID)
+	}
+	if transaction.Type != "payment" {
+		t.Errorf("Expected type payment, got: %v", transaction.Type)
+	}
+}
+
+func TestRetrieveTransactionWithParams(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("Expected GET, got: %v", r.Method)
+				}
+				validationType := r.URL.Query().Get("validation_type")
+				if validationType != "all" {
+					t.Errorf("Expected validation_type=all, got: %v", validationType)
+				}
+				w.Write([]byte(retrieveTransactionExample)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	transaction, err := tested.RetrieveTransaction("tr_879d560a-1bec-41bb-986e-665e38a2f7bc", &RetrieveTransactionParams{
+		ValidationType: "all",
+	})
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if transaction.UUID != "tr_879d560a-1bec-41bb-986e-665e38a2f7bc" {
+		t.Errorf("Expected UUID tr_879d560a-1bec-41bb-986e-665e38a2f7bc, got: %v", transaction.UUID)
+	}
+}
+
+func TestUpdateTransaction(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "PATCH"
+				if r.Method != expectedMethod {
+					t.Errorf("Requested method expected: %v, actual: %v", expectedMethod, r.Method)
+				}
+				expected := "/v/transactions/tr_123"
+				path := r.URL.Path
+				if path != expected {
+					t.Errorf("Requested path expected: %v, actual: %v", expected, path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+				defer r.Body.Close()
+				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal("error should be nil")
+				}
+				expectedBody := `{"date":"2015-12-01T00:00:00.000Z","result":"failed"}`
+				if string(body) != expectedBody {
+					t.Errorf("Requested body expected: %v, actual: %v", expectedBody, string(body))
+				}
+				w.Write([]byte(`{"uuid":"tr_123","type":"payment","date":"2015-12-01T00:00:00.000Z","result":"failed"}`)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	transaction, err := tested.UpdateTransaction("tr_123", &UpdateTransactionParams{
+		Date:   "2015-12-01T00:00:00.000Z",
+		Result: "failed",
+	})
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if transaction.UUID != "tr_123" {
+		t.Errorf("Expected UUID tr_123, got: %v", transaction.UUID)
+	}
+	if transaction.Result != "failed" {
+		t.Errorf("Expected result failed, got: %v", transaction.Result)
+	}
+}
+
+func TestToggleTransactionDisabled(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "PATCH"
+				if r.Method != expectedMethod {
+					t.Errorf("Requested method expected: %v, actual: %v", expectedMethod, r.Method)
+				}
+				expected := "/v/transactions/tr_123/disabled_state"
+				path := r.URL.Path
+				if path != expected {
+					t.Errorf("Requested path expected: %v, actual: %v", expected, path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+				defer r.Body.Close()
+				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal("error should be nil")
+				}
+				expectedBody := `{"disabled":true}`
+				if string(body) != expectedBody {
+					t.Errorf("Requested body expected: %v, actual: %v", expectedBody, string(body))
+				}
+				w.Write([]byte(`{"uuid":"tr_123","type":"payment","date":"2015-11-05T00:14:23.000Z","result":"successful","disabled":true,"disabled_at":"2026-03-17T10:00:00.000Z","disabled_by":"user@example.com"}`)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	transaction, err := tested.ToggleTransactionDisabled("tr_123", &ToggleTransactionDisabledParams{
+		Disabled: true,
+	})
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if transaction.UUID != "tr_123" {
+		t.Errorf("Expected UUID tr_123, got: %v", transaction.UUID)
+	}
+	if transaction.Disabled == nil || *transaction.Disabled != true {
+		t.Error("Expected disabled to be true")
+	}
+}
+
+func TestDeleteTransaction(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expected := "/v/transactions/tr_123"
+				path := r.URL.Path
+				if path != expected {
+					t.Errorf("Requested path expected: %v, actual: %v", expected, path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	err := tested.DeleteTransaction("tr_123")
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+}


### PR DESCRIPTION
## Summary
- Add retrieve (with optional query params), update, toggle disabled state, and delete endpoints for transactions
- Extend `Transaction` model with `Disabled`, `DisabledAt`, `DisabledBy`, `UserCreated`, `EditHistorySummary`, `TransactionFeesCurrency` fields
- Add unit tests for all new endpoints

Linear: [PIP-308](https://linear.app/chartmogul/issue/PIP-308/add-missing-api-features-to-sdks)

## Backwards compatibility

All changes are **purely additive** — no existing public API surface was modified or removed.

| Change | Breaking? |
|---|---|
| Added `RetrieveTransaction`, `UpdateTransaction`, `ToggleTransactionDisabled`, `DeleteTransaction` methods | No — new methods |
| Added `TransactionFeesCurrency`, `Disabled`, `DisabledAt`, `DisabledBy`, `UserCreated`, `EditHistorySummary` fields to `Transaction` struct | No — all use `omitempty`, existing code unaffected |
| Added methods to `IApi` interface | No — only affects mock consumers who must regenerate (mock included) |

## Testing instructions

```go
api := &cm.API{ApiKey: os.Getenv("CHARTMOGUL_API_KEY")}
```

### Retrieve a transaction

```go
tx, err := api.RetrieveTransaction("tr_...")
fmt.Println(tx.Type, tx.Result, tx.Date)

// With optional params
trueBool := true
tx, err := api.RetrieveTransaction("tr_...", &cm.RetrieveTransactionParams{
    ValidationType:       "all",
    IncludeEditHistories: &trueBool,
    WithDisabled:         &trueBool,
})
```

### Update a transaction

```go
tx, err := api.UpdateTransaction("tr_...", &cm.UpdateTransactionParams{
    Date:   "2026-01-15T00:00:00.000Z",
    Result: "failed",
})
fmt.Println(tx.Result)
```

### Toggle transaction disabled state

```go
tx, err := api.ToggleTransactionDisabled("tr_...", &cm.ToggleTransactionDisabledParams{
    Disabled: true,
})
fmt.Println(*tx.Disabled, tx.DisabledAt)
```

### Delete a transaction

```go
err := api.DeleteTransaction("tr_...")
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Mock regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)