### PR TITLE
Add update invoice endpoint

### DIFF
--- a/chartmogul.go
+++ b/chartmogul.go
@@ -63,6 +63,7 @@ type IApi interface {
 	ListInvoices(cursor *Cursor, customerUUID string) (*Invoices, error)
 	ListAllInvoices(listAllInvoicesParams *ListAllInvoicesParams) (*Invoices, error)
 	RetrieveInvoice(invoiceUUID string, params ...*RetrieveInvoiceParams) (*Invoice, error)
+	UpdateInvoice(invoiceUUID string, params *UpdateInvoiceParams) (*Invoice, error)
 	DeleteInvoice(invoiceUUID string) error
 	UpdateInvoiceStatus(dataSourceUUID, invoiceExternalID string, params *UpdateInvoiceStatusParams) error
 	ToggleInvoiceDisabled(invoiceUUID string, params *ToggleInvoiceDisabledParams) (*Invoice, error)

--- a/invoices.go
+++ b/invoices.go
@@ -42,11 +42,14 @@ type Invoice struct {
 	Date               string              `json:"date"`
 	DueDate            string              `json:"due_date,omitempty"`
 	ExternalID         string              `json:"external_id"`
+	CollectionMethod   string              `json:"collection_method,omitempty"`
+	Status             string              `json:"status,omitempty"`
 	LineItems          []*LineItem         `json:"line_items"`
 	Transactions       []*Transaction      `json:"transactions,omitempty"`
 	Disabled           *bool               `json:"disabled,omitempty"`
 	DisabledAt         string              `json:"disabled_at,omitempty"`
 	DisabledBy         string              `json:"disabled_by,omitempty"`
+	UserCreated        *bool               `json:"user_created,omitempty"`
 	EditHistorySummary *EditHistorySummary `json:"edit_history_summary,omitempty"`
 	Errors             *InvoiceErrors      `json:"errors,omitempty"`
 }
@@ -180,4 +183,18 @@ type ToggleInvoiceDisabledParams struct {
 func (api API) ToggleInvoiceDisabled(invoiceUUID string, params *ToggleInvoiceDisabledParams) (*Invoice, error) {
 	result := &Invoice{}
 	return result, api.update(invoiceDisabledStateEndpoint, invoiceUUID, params, result)
+}
+
+// UpdateInvoiceParams holds the parameters for UpdateInvoice.
+type UpdateInvoiceParams struct {
+	Date             string `json:"date,omitempty"`
+	DueDate          string `json:"due_date,omitempty"`
+	Currency         string `json:"currency,omitempty"`
+	CollectionMethod string `json:"collection_method,omitempty"`
+}
+
+// UpdateInvoice updates an invoice by UUID.
+func (api API) UpdateInvoice(invoiceUUID string, params *UpdateInvoiceParams) (*Invoice, error) {
+	result := &Invoice{}
+	return result, api.update(singleInvoiceEndpoint, invoiceUUID, params, result)
 }

--- a/invoices_test.go
+++ b/invoices_test.go
@@ -687,6 +687,45 @@ func TestRetrieveInvoiceWithLineItemErrors(t *testing.T) {
 	}
 }
 
+func TestUpdateInvoice(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "PATCH"
+				if r.Method != expectedMethod {
+					t.Errorf("Requested method expected: %v, actual: %v", expectedMethod, r.Method)
+				}
+				expected := "/v/invoices/inv_123"
+				path := r.URL.Path
+				if path != expected {
+					t.Errorf("Requested path expected: %v, actual: %v", expected, path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+				w.Write([]byte(`{"uuid":"inv_123","external_id":"INV0001","date":"2015-12-01T00:00:00.000Z","currency":"EUR","line_items":[],"transactions":[]}`)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	invoice, err := tested.UpdateInvoice("inv_123", &UpdateInvoiceParams{
+		Date:     "2015-12-01T00:00:00.000Z",
+		Currency: "EUR",
+	})
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if invoice.UUID != "inv_123" {
+		t.Errorf("Expected UUID inv_123, got: %v", invoice.UUID)
+	}
+	if invoice.Currency != "EUR" {
+		t.Errorf("Expected currency EUR, got: %v", invoice.Currency)
+	}
+}
+
 func TestCreateInvoiceFullRefund(t *testing.T) {
 	server := httptest.NewServer(
 		http.HandlerFunc(

--- a/mock_chartmogul/chartmogul.go
+++ b/mock_chartmogul/chartmogul.go
@@ -1446,6 +1446,21 @@ func (mr *MockIApiMockRecorder) UpdateCustomerV2(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCustomerV2", reflect.TypeOf((*MockIApi)(nil).UpdateCustomerV2), arg0, arg1)
 }
 
+// UpdateInvoice mocks base method
+func (m *MockIApi) UpdateInvoice(arg0 string, arg1 *chartmogul.UpdateInvoiceParams) (*chartmogul.Invoice, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateInvoice", arg0, arg1)
+	ret0, _ := ret[0].(*chartmogul.Invoice)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateInvoice indicates an expected call of UpdateInvoice
+func (mr *MockIApiMockRecorder) UpdateInvoice(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInvoice", reflect.TypeOf((*MockIApi)(nil).UpdateInvoice), arg0, arg1)
+}
+
 // UpdateInvoiceStatus mocks base method
 func (m *MockIApi) UpdateInvoiceStatus(arg0, arg1 string, arg2 *chartmogul.UpdateInvoiceStatusParams) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary
- Add `UpdateInvoice` method (`PATCH /invoices/:uuid`) to update date, due_date, currency, and collection_method
- Extend `Invoice` model with `CollectionMethod`, `Status`, and `UserCreated` fields
- Add unit test for the new endpoint

Linear: [PIP-308](https://linear.app/chartmogul/issue/PIP-308/add-missing-api-features-to-sdks)

## Backwards compatibility

All changes are **purely additive** — no existing public API surface was modified or removed.

| Change | Breaking? |
|---|---|
| Added `UpdateInvoice` method and `UpdateInvoiceParams` struct | No — new method |
| Added `CollectionMethod`, `Status`, `UserCreated` fields to `Invoice` struct | No — all use `omitempty`, existing code unaffected |
| Added method to `IApi` interface | No — only affects mock consumers who must regenerate (mock included) |

## Testing instructions

```go
api := &cm.API{ApiKey: os.Getenv("CHARTMOGUL_API_KEY")}
```

### Update an invoice

```go
invoice, err := api.UpdateInvoice("inv_...", &cm.UpdateInvoiceParams{
    Date:     "2026-02-01T00:00:00.000Z",
    Currency: "EUR",
})
fmt.Println(invoice.UUID, invoice.Currency)

// Update with all fields
invoice, err := api.UpdateInvoice("inv_...", &cm.UpdateInvoiceParams{
    Date:             "2026-02-01T00:00:00.000Z",
    DueDate:          "2026-02-15T00:00:00.000Z",
    Currency:         "EUR",
    CollectionMethod: "manual",
})
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Mock regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)