### PR TITLE
Add bulk import (JSON imports) endpoints

### DIFF
--- a/chartmogul.go
+++ b/chartmogul.go
@@ -171,6 +171,10 @@ type IApi interface {
 	// Account
 	RetrieveAccount(params ...*RetrieveAccountParams) (*Account, error)
 
+	// Bulk Import
+	CreateJsonImport(dataSourceUUID string, data *JsonImportData) (*JsonImport, error)
+	RetrieveJsonImport(dataSourceUUID string, importID string) (*JsonImport, error)
+
 	// Subscription Events
 	ListSubscriptionEvents(filters *FilterSubscriptionEvents, cursor *Cursor) (*SubscriptionEvents, error)
 	CreateSubscriptionEvent(newSubscriptionEvent *SubscriptionEvent) (*SubscriptionEvent, error)

--- a/json_imports.go
+++ b/json_imports.go
@@ -3,8 +3,8 @@ package chartmogul
 import "strings"
 
 const (
-	jsonImportsEndpoint       = "data_sources/:dataSourceUUID/json_imports"
-	singleJsonImportEndpoint  = "data_sources/:dataSourceUUID/json_imports/:id"
+	jsonImportsEndpoint      = "data_sources/:dataSourceUUID/json_imports"
+	singleJsonImportEndpoint = "data_sources/:dataSourceUUID/json_imports/:id"
 )
 
 // JsonImport represents the response from a bulk import operation.

--- a/json_imports.go
+++ b/json_imports.go
@@ -1,0 +1,128 @@
+package chartmogul
+
+import "strings"
+
+const (
+	jsonImportsEndpoint       = "data_sources/:dataSourceUUID/json_imports"
+	singleJsonImportEndpoint  = "data_sources/:dataSourceUUID/json_imports/:id"
+)
+
+// JsonImport represents the response from a bulk import operation.
+type JsonImport struct {
+	ID             string      `json:"id,omitempty"`
+	DataSourceUUID string      `json:"data_source_uuid,omitempty"`
+	Status         string      `json:"status,omitempty"`
+	ExternalID     string      `json:"external_id,omitempty"`
+	StatusDetails  interface{} `json:"status_details,omitempty"`
+	CreatedAt      string      `json:"created_at,omitempty"`
+	UpdatedAt      string      `json:"updated_at,omitempty"`
+}
+
+// JsonImportData represents the request body for creating a bulk import.
+type JsonImportData struct {
+	ExternalID         string                         `json:"external_id"`
+	Customers          []*JsonImportCustomer          `json:"customers,omitempty"`
+	Plans              []*JsonImportPlan              `json:"plans,omitempty"`
+	Invoices           []*JsonImportInvoice           `json:"invoices,omitempty"`
+	LineItems          []*JsonImportLineItem          `json:"line_items,omitempty"`
+	Transactions       []*JsonImportTransaction       `json:"transactions,omitempty"`
+	SubscriptionEvents []*JsonImportSubscriptionEvent `json:"subscription_events,omitempty"`
+}
+
+// JsonImportCustomer represents a customer in a bulk import.
+type JsonImportCustomer struct {
+	ExternalID         string `json:"external_id"`
+	Name               string `json:"name,omitempty"`
+	Email              string `json:"email,omitempty"`
+	Country            string `json:"country,omitempty"`
+	State              string `json:"state,omitempty"`
+	City               string `json:"city,omitempty"`
+	Zip                string `json:"zip,omitempty"`
+	Company            string `json:"company,omitempty"`
+	LeadCreatedAt      string `json:"lead_created_at,omitempty"`
+	FreeTrialStartedAt string `json:"free_trial_started_at,omitempty"`
+}
+
+// JsonImportPlan represents a plan in a bulk import.
+type JsonImportPlan struct {
+	Name          string `json:"name"`
+	IntervalCount int    `json:"interval_count"`
+	IntervalUnit  string `json:"interval_unit"`
+	ExternalID    string `json:"external_id,omitempty"`
+}
+
+// JsonImportInvoice represents an invoice in a bulk import.
+type JsonImportInvoice struct {
+	CustomerExternalID string `json:"customer_external_id"`
+	ExternalID         string `json:"external_id"`
+	Date               string `json:"date"`
+	DueDate            string `json:"due_date,omitempty"`
+	Currency           string `json:"currency,omitempty"`
+	CollectionMethod   string `json:"collection_method,omitempty"`
+}
+
+// JsonImportLineItem represents a line item in a bulk import.
+type JsonImportLineItem struct {
+	InvoiceExternalID         string `json:"invoice_external_id"`
+	Type                      string `json:"type"`
+	AmountInCents             int    `json:"amount_in_cents"`
+	ExternalID                string `json:"external_id,omitempty"`
+	SubscriptionExternalID    string `json:"subscription_external_id,omitempty"`
+	SubscriptionSetExternalID string `json:"subscription_set_external_id,omitempty"`
+	PlanExternalID            string `json:"plan_external_id,omitempty"`
+	ServicePeriodStart        string `json:"service_period_start,omitempty"`
+	ServicePeriodEnd          string `json:"service_period_end,omitempty"`
+	Prorated                  *bool  `json:"prorated,omitempty"`
+	ProrationType             string `json:"proration_type,omitempty"`
+	Description               string `json:"description,omitempty"`
+	Quantity                  *int   `json:"quantity,omitempty"`
+	DiscountAmountInCents     *int   `json:"discount_amount_in_cents,omitempty"`
+	DiscountCode              string `json:"discount_code,omitempty"`
+	TaxAmountInCents          *int   `json:"tax_amount_in_cents,omitempty"`
+	TransactionFeesInCents    *int   `json:"transaction_fees_in_cents,omitempty"`
+	TransactionFeesCurrency   string `json:"transaction_fees_currency,omitempty"`
+	DiscountDescription       string `json:"discount_description,omitempty"`
+	EventOrder                *int   `json:"event_order,omitempty"`
+}
+
+// JsonImportTransaction represents a transaction in a bulk import.
+type JsonImportTransaction struct {
+	InvoiceExternalID string `json:"invoice_external_id"`
+	Type              string `json:"type"`
+	Result            string `json:"result"`
+	Date              string `json:"date"`
+	ExternalID        string `json:"external_id,omitempty"`
+	AmountInCents     *int   `json:"amount_in_cents,omitempty"`
+}
+
+// JsonImportSubscriptionEvent represents a subscription event in a bulk import.
+type JsonImportSubscriptionEvent struct {
+	CustomerExternalID        string `json:"customer_external_id"`
+	EventType                 string `json:"event_type"`
+	EventDate                 string `json:"event_date"`
+	EffectiveDate             string `json:"effective_date"`
+	SubscriptionExternalID    string `json:"subscription_external_id,omitempty"`
+	SubscriptionSetExternalID string `json:"subscription_set_external_id,omitempty"`
+	ExternalID                string `json:"external_id,omitempty"`
+	PlanExternalID            string `json:"plan_external_id,omitempty"`
+	Currency                  string `json:"currency,omitempty"`
+	AmountInCents             *int   `json:"amount_in_cents,omitempty"`
+	Quantity                  *int   `json:"quantity,omitempty"`
+	TaxAmountInCents          *int   `json:"tax_amount_in_cents,omitempty"`
+	RetractedEventId          string `json:"retracted_event_id,omitempty"`
+}
+
+// CreateJsonImport creates a bulk import for a data source.
+func (api API) CreateJsonImport(dataSourceUUID string, data *JsonImportData) (*JsonImport, error) {
+	result := &JsonImport{}
+	path := strings.Replace(jsonImportsEndpoint, ":dataSourceUUID", dataSourceUUID, 1)
+	return result, api.create(path, data, result)
+}
+
+// RetrieveJsonImport retrieves the status of a bulk import.
+func (api API) RetrieveJsonImport(dataSourceUUID string, importID string) (*JsonImport, error) {
+	result := &JsonImport{}
+	path := strings.Replace(singleJsonImportEndpoint, ":dataSourceUUID", dataSourceUUID, 1)
+	path = strings.Replace(path, ":id", importID, 1)
+	return result, api.retrieve(path, "", result)
+}

--- a/json_imports_test.go
+++ b/json_imports_test.go
@@ -1,0 +1,119 @@
+package chartmogul
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+const createJsonImportExample = `{
+	"id": "imp_12345",
+	"data_source_uuid": "ds_abc123",
+	"status": "queued",
+	"external_id": "batch_001",
+	"created_at": "2026-03-17T10:00:00.000Z",
+	"updated_at": "2026-03-17T10:00:00.000Z"
+}`
+
+const retrieveJsonImportExample = `{
+	"id": "imp_12345",
+	"data_source_uuid": "ds_abc123",
+	"status": "completed",
+	"external_id": "batch_001",
+	"created_at": "2026-03-17T10:00:00.000Z",
+	"updated_at": "2026-03-17T10:05:00.000Z"
+}`
+
+func TestCreateJsonImport(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "POST"
+				if r.Method != expectedMethod {
+					t.Errorf("Requested method expected: %v, actual: %v", expectedMethod, r.Method)
+				}
+				expected := "/v/data_sources/ds_abc123/json_imports"
+				path := r.URL.Path
+				if path != expected {
+					t.Errorf("Requested path expected: %v, actual: %v", expected, path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+				w.Write([]byte(createJsonImportExample)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	result, err := tested.CreateJsonImport("ds_abc123", &JsonImportData{
+		ExternalID: "batch_001",
+		Customers: []*JsonImportCustomer{
+			{
+				ExternalID: "cus_ext_001",
+				Name:       "Test Customer",
+				Email:      "test@example.com",
+			},
+		},
+		Plans: []*JsonImportPlan{
+			{
+				Name:          "Basic Plan",
+				IntervalCount: 1,
+				IntervalUnit:  "month",
+				ExternalID:    "plan_ext_001",
+			},
+		},
+	})
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if result.ID != "imp_12345" {
+		t.Errorf("Expected ID imp_12345, got: %v", result.ID)
+	}
+	if result.Status != "queued" {
+		t.Errorf("Expected status queued, got: %v", result.Status)
+	}
+	if result.ExternalID != "batch_001" {
+		t.Errorf("Expected external_id batch_001, got: %v", result.ExternalID)
+	}
+}
+
+func TestRetrieveJsonImport(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "GET"
+				if r.Method != expectedMethod {
+					t.Errorf("Requested method expected: %v, actual: %v", expectedMethod, r.Method)
+				}
+				expected := "/v/data_sources/ds_abc123/json_imports/imp_12345"
+				path := r.URL.Path
+				if path != expected {
+					t.Errorf("Requested path expected: %v, actual: %v", expected, path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+				w.Write([]byte(retrieveJsonImportExample)) //nolint
+			}))
+	defer server.Close()
+	SetURL(server.URL + "/v/%v")
+
+	var tested IApi = &API{
+		ApiKey: "token",
+	}
+	result, err := tested.RetrieveJsonImport("ds_abc123", "imp_12345")
+
+	if err != nil {
+		spew.Dump(err)
+		t.Fatal("Not expected to fail")
+	}
+	if result.ID != "imp_12345" {
+		t.Errorf("Expected ID imp_12345, got: %v", result.ID)
+	}
+	if result.Status != "completed" {
+		t.Errorf("Expected status completed, got: %v", result.Status)
+	}
+}

--- a/json_imports_test.go
+++ b/json_imports_test.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 const createJsonImportExample = `{
@@ -68,8 +66,7 @@ func TestCreateJsonImport(t *testing.T) {
 	})
 
 	if err != nil {
-		spew.Dump(err)
-		t.Fatal("Not expected to fail")
+		t.Fatal("Not expected to fail:", err)
 	}
 	if result.ID != "imp_12345" {
 		t.Errorf("Expected ID imp_12345, got: %v", result.ID)
@@ -107,8 +104,7 @@ func TestRetrieveJsonImport(t *testing.T) {
 	result, err := tested.RetrieveJsonImport("ds_abc123", "imp_12345")
 
 	if err != nil {
-		spew.Dump(err)
-		t.Fatal("Not expected to fail")
+		t.Fatal("Not expected to fail:", err)
 	}
 	if result.ID != "imp_12345" {
 		t.Errorf("Expected ID imp_12345, got: %v", result.ID)

--- a/mock_chartmogul/chartmogul.go
+++ b/mock_chartmogul/chartmogul.go
@@ -242,6 +242,21 @@ func (mr *MockIApiMockRecorder) CreateInvoices(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInvoices", reflect.TypeOf((*MockIApi)(nil).CreateInvoices), arg0, arg1)
 }
 
+// CreateJsonImport mocks base method
+func (m *MockIApi) CreateJsonImport(arg0 string, arg1 *chartmogul.JsonImportData) (*chartmogul.JsonImport, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateJsonImport", arg0, arg1)
+	ret0, _ := ret[0].(*chartmogul.JsonImport)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateJsonImport indicates an expected call of CreateJsonImport
+func (mr *MockIApiMockRecorder) CreateJsonImport(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateJsonImport", reflect.TypeOf((*MockIApi)(nil).CreateJsonImport), arg0, arg1)
+}
+
 // CreateLineItems mocks base method
 func (m *MockIApi) CreateLineItems(arg0 string, arg1 []*chartmogul.LineItem) (*chartmogul.LineItems, error) {
 	m.ctrl.T.Helper()
@@ -1215,6 +1230,21 @@ func (mr *MockIApiMockRecorder) RetrieveInvoice(arg0 interface{}, arg1 ...interf
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveInvoice", reflect.TypeOf((*MockIApi)(nil).RetrieveInvoice), varargs...)
+}
+
+// RetrieveJsonImport mocks base method
+func (m *MockIApi) RetrieveJsonImport(arg0, arg1 string) (*chartmogul.JsonImport, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RetrieveJsonImport", arg0, arg1)
+	ret0, _ := ret[0].(*chartmogul.JsonImport)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RetrieveJsonImport indicates an expected call of RetrieveJsonImport
+func (mr *MockIApiMockRecorder) RetrieveJsonImport(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveJsonImport", reflect.TypeOf((*MockIApi)(nil).RetrieveJsonImport), arg0, arg1)
 }
 
 // RetrieveLineItem mocks base method


### PR DESCRIPTION
## Summary
- Add `CreateJsonImport` and `RetrieveJsonImport` methods for bulk data import via `/data_sources/:uuid/json_imports`
- Include typed request structs for all importable entities: customers, plans, invoices, line items, transactions, and subscription events
- Add unit tests for both endpoints

Linear: [PIP-308](https://linear.app/chartmogul/issue/PIP-308/add-missing-api-features-to-sdks)

## Backwards compatibility

All changes are **purely additive** — no existing public API surface was modified or removed.

| Change | Breaking? |
|---|---|
| New `json_imports.go` with `CreateJsonImport`, `RetrieveJsonImport` and all `JsonImport*` structs | No — new file, new types |
| Added methods to `IApi` interface | No — only affects mock consumers who must regenerate (mock included) |

## Testing instructions

```go
api := &cm.API{ApiKey: os.Getenv("CHARTMOGUL_API_KEY")}
```

### Create a bulk import

```go
quantity := 1
result, err := api.CreateJsonImport("ds_...", &cm.JsonImportData{
    ExternalID: "batch_001",
    Customers: []*cm.JsonImportCustomer{
        {
            ExternalID: "cus_ext_001",
            Name:       "Acme Corp",
            Email:      "billing@acme.com",
            Country:    "US",
        },
    },
    Plans: []*cm.JsonImportPlan{
        {
            Name:          "Pro Monthly",
            IntervalCount: 1,
            IntervalUnit:  "month",
            ExternalID:    "plan_pro_monthly",
        },
    },
    Invoices: []*cm.JsonImportInvoice{
        {
            CustomerExternalID: "cus_ext_001",
            ExternalID:         "inv_ext_001",
            Date:               "2026-01-01T00:00:00.000Z",
            Currency:           "USD",
        },
    },
    LineItems: []*cm.JsonImportLineItem{
        {
            InvoiceExternalID:      "inv_ext_001",
            Type:                   "subscription",
            AmountInCents:          5000,
            SubscriptionExternalID: "sub_ext_001",
            PlanExternalID:         "plan_pro_monthly",
            ServicePeriodStart:     "2026-01-01T00:00:00.000Z",
            ServicePeriodEnd:       "2026-02-01T00:00:00.000Z",
            Quantity:               &quantity,
        },
    },
    Transactions: []*cm.JsonImportTransaction{
        {
            InvoiceExternalID: "inv_ext_001",
            Type:              "payment",
            Result:            "successful",
            Date:              "2026-01-01T00:00:00.000Z",
        },
    },
})
fmt.Println(result.ID, result.Status) // e.g. "imp_12345" "queued"
```

### Retrieve import status

```go
status, err := api.RetrieveJsonImport("ds_...", "imp_12345")
fmt.Println(status.Status) // "queued", "processing", "completed", or "failed"
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Mock regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)