### PR TITLE
Replace softprops/action-gh-release with built-in gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        with:
-          generate_release_notes: true
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes


### PR DESCRIPTION
## Summary

- Remove third-party `softprops/action-gh-release` action from the release workflow
- Use the `gh release create` CLI command instead, which is pre-installed on GitHub runners

Follow-up to #87.

## Test plan

- [ ] Push a test tag (e.g., `v4.13.0-rc1`) and confirm a GitHub Release is created with auto-generated notes
- [x] Verify zizmor passes on the updated workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)