### PR TITLE
Add AI coding agent instruction files and Claude Code hooks

### DIFF
--- a/.claude/hooks/post-commit-lint.sh
+++ b/.claude/hooks/post-commit-lint.sh
@@ -18,7 +18,7 @@ FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | grep '\.go$' || true)
 
 # Run golangci-lint on committed files only
 if [ -x ./bin/golangci-lint ]; then
-  LINT_OUTPUT=$(./bin/golangci-lint run $FILES 2>&1)
+  LINT_OUTPUT=$(echo "$FILES" | xargs ./bin/golangci-lint run 2>&1)
   LINT_EXIT=$?
   if [ $LINT_EXIT -ne 0 ]; then
     CTX=$(echo "$LINT_OUTPUT" | head -20)

--- a/.claude/hooks/post-commit-lint.sh
+++ b/.claude/hooks/post-commit-lint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# PostToolUse (Bash, scoped to git commit): lint files in the just-created
+# commit and report failures as context. Must not run tests.
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Only fire after git commit commands
+case "$CMD" in
+  git\ commit*) ;;
+  *) exit 0 ;;
+esac
+
+# Get .go files changed in the last commit
+FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | grep '\.go$' || true)
+[[ -z "$FILES" ]] && exit 0
+
+# Run golangci-lint on committed files only
+if [ -x ./bin/golangci-lint ]; then
+  LINT_OUTPUT=$(./bin/golangci-lint run $FILES 2>&1)
+  LINT_EXIT=$?
+  if [ $LINT_EXIT -ne 0 ]; then
+    CTX=$(echo "$LINT_OUTPUT" | head -20)
+    jq -n --arg ctx "golangci-lint found issues in committed files:\n$CTX" \
+      '{"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": $ctx}}' || true
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -5,6 +5,7 @@ cd "$CLAUDE_PROJECT_DIR" || exit 0
 
 INPUT=$(cat)
 FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "default"')
 
 [[ -z "$FILE" ]] && exit 0
 
@@ -16,8 +17,8 @@ esac
 # Only track .go files
 [[ "$FILE" != *.go ]] && exit 0
 
-# Append to session-scoped tracker (dedup happens in Stop hook)
-TRACKER="/tmp/claude-edited-go-files-${CLAUDE_HOOK_SESSION_ID:-default}"
+# Append to session-scoped tracker, respecting TMPDIR
+TRACKER="${TMPDIR:-/tmp}/claude-edited-go-files-${CLAUDE_HOOK_SESSION_ID:-$SESSION_ID}"
 echo "$FILE" >> "$TRACKER"
 sort -u "$TRACKER" -o "$TRACKER"
 

--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -1,12 +1,23 @@
 #!/bin/bash
+# PostToolUse (Edit|Write|MultiEdit): record edited file path for batch
+# processing in Stop hook. Must be <50ms - no formatting, no linting, no git.
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
 INPUT=$(cat)
 FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
-if [[ "$FILE" == *.go ]]; then
-  gofmt -w "$FILE" 2>/dev/null
-  if [ -x ./bin/golangci-lint ]; then
-    ./bin/golangci-lint run --fix "$FILE" 2>&1
-  fi
-fi
+[[ -z "$FILE" ]] && exit 0
+
+# Skip generated/vendored paths
+case "$FILE" in
+  */vendor/*|*/mock_chartmogul/*|*/coverage/*|*/dist/*|*/__pycache__/*) exit 0 ;;
+esac
+
+# Only track .go files
+[[ "$FILE" != *.go ]] && exit 0
+
+# Append to tracker file (dedup happens in Stop hook)
+TRACKER="$CLAUDE_PROJECT_DIR/.claude/.edited_files"
+echo "$FILE" >> "$TRACKER" 2>/dev/null || true
 
 exit 0

--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ "$FILE" == *.go ]]; then
+  gofmt -w "$FILE" 2>/dev/null
+  if [ -x ./bin/golangci-lint ]; then
+    ./bin/golangci-lint run --fix "$FILE" 2>&1
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -10,14 +10,15 @@ FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
 # Skip generated/vendored paths
 case "$FILE" in
-  */vendor/*|*/mock_chartmogul/*|*/coverage/*|*/dist/*|*/__pycache__/*) exit 0 ;;
+  */vendor/*|*/mock_chartmogul/*|*/coverage/*) exit 0 ;;
 esac
 
 # Only track .go files
 [[ "$FILE" != *.go ]] && exit 0
 
-# Append to tracker file (dedup happens in Stop hook)
-TRACKER="$CLAUDE_PROJECT_DIR/.claude/.edited_files"
-echo "$FILE" >> "$TRACKER" 2>/dev/null || true
+# Append to session-scoped tracker (dedup happens in Stop hook)
+TRACKER="/tmp/claude-edited-go-files-${CLAUDE_HOOK_SESSION_ID:-default}"
+echo "$FILE" >> "$TRACKER"
+sort -u "$TRACKER" -o "$TRACKER"
 
 exit 0

--- a/.claude/hooks/post-stop-validate.sh
+++ b/.claude/hooks/post-stop-validate.sh
@@ -1,32 +1,36 @@
 #!/bin/bash
 # Stop: batch-format files touched this turn, run lint + tests, report failures.
-# Tests run unconditionally (~2s) since edits to test or lib code both matter.
+# Tests and lint only run when files were tracked this turn.
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-TRACKER="/tmp/claude-edited-go-files-${CLAUDE_HOOK_SESSION_ID:-default}"
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "default"')
+TRACKER="${TMPDIR:-/tmp}/claude-edited-go-files-${CLAUDE_HOOK_SESSION_ID:-$SESSION_ID}"
+
+# Nothing tracked this turn - skip everything
+[[ ! -f "$TRACKER" ]] && exit 0
+
+files=$(cat "$TRACKER")
+rm -f "$TRACKER"
+
+[[ -z "$files" ]] && exit 0
 
 ctx=""
 
-# Batch gofmt + golangci-lint on tracked files (if any were edited)
-if [[ -f "$TRACKER" ]]; then
-  files=$(cat "$TRACKER")
-  rm -f "$TRACKER"
+# 1. Autoformat touched files
+echo "$files" | xargs gofmt -w 2>/dev/null || true
 
-  if [[ -n "$files" ]]; then
-    echo "$files" | xargs gofmt -w 2>/dev/null || true
-
-    if [ -x ./bin/golangci-lint ]; then
-      lint_out=$(echo "$files" | xargs ./bin/golangci-lint run --fix 2>&1)
-      lint_exit=$?
-      if [ $lint_exit -ne 0 ]; then
-        offenses=$(echo "$lint_out" | head -20)
-        ctx+="golangci-lint offenses remaining after autocorrect:\n$offenses\n"
-      fi
-    fi
+# 2. Lint touched files and report remaining offenses
+if [ -x ./bin/golangci-lint ]; then
+  lint_out=$(echo "$files" | xargs ./bin/golangci-lint run --fix 2>&1)
+  lint_exit=$?
+  if [ $lint_exit -ne 0 ]; then
+    offenses=$(echo "$lint_out" | head -20)
+    ctx+="golangci-lint offenses remaining after autocorrect:\n$offenses\n"
   fi
 fi
 
-# Always run tests - edits to test or lib code both matter (~2s)
+# 3. Run test suite (~2s)
 test_out=$(go test -timeout=30s ./... 2>&1)
 test_exit=$?
 if [[ $test_exit -ne 0 ]]; then

--- a/.claude/hooks/post-stop-validate.sh
+++ b/.claude/hooks/post-stop-validate.sh
@@ -1,40 +1,46 @@
 #!/bin/bash
 # Stop: batch-format files touched this turn, run lint + tests, report failures.
-# Suite takes ~2s so it's cheap enough to run every turn.
+# Tests run unconditionally (~2s) since edits to test or lib code both matter.
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-TRACKER="$CLAUDE_PROJECT_DIR/.claude/.edited_files"
-ERRORS=""
+TRACKER="/tmp/claude-edited-go-files-${CLAUDE_HOOK_SESSION_ID:-default}"
 
-# Nothing tracked this turn - skip everything
-[[ ! -f "$TRACKER" ]] && exit 0
+ctx=""
 
-# Dedup tracked files, filter to existing .go files
-FILES=$(sort -u "$TRACKER" | while read -r f; do [[ -f "$f" ]] && echo "$f"; done)
-rm -f "$TRACKER" 2>/dev/null
+# Batch gofmt + golangci-lint on tracked files (if any were edited)
+if [[ -f "$TRACKER" ]]; then
+  files=$(cat "$TRACKER")
+  rm -f "$TRACKER"
 
-[[ -z "$FILES" ]] && exit 0
+  if [[ -n "$files" ]]; then
+    echo "$files" | xargs gofmt -w 2>/dev/null || true
 
-# 1. Autoformat touched files
-echo "$FILES" | xargs gofmt -w 2>/dev/null || true
-
-# 2. Lint touched files and report remaining offenses
-if [ -x ./bin/golangci-lint ]; then
-  LINT_OUTPUT=$(echo "$FILES" | xargs ./bin/golangci-lint run --fix 2>&1)
-  if [ $? -ne 0 ]; then
-    ERRORS="$ERRORS\n## golangci-lint\n$(echo "$LINT_OUTPUT" | head -20)"
+    if [ -x ./bin/golangci-lint ]; then
+      lint_out=$(echo "$files" | xargs ./bin/golangci-lint run --fix 2>&1)
+      lint_exit=$?
+      if [ $lint_exit -ne 0 ]; then
+        offenses=$(echo "$lint_out" | head -20)
+        ctx+="golangci-lint offenses remaining after autocorrect:\n$offenses\n"
+      fi
+    fi
   fi
 fi
 
-# 3. Run full test suite (~2s)
-TEST_OUTPUT=$(go test -timeout=30s ./... 2>&1)
-if [ $? -ne 0 ]; then
-  ERRORS="$ERRORS\n## go test\n$(echo "$TEST_OUTPUT" | grep -E 'FAIL|Error|panic' | head -20)"
+# Always run tests - edits to test or lib code both matter (~2s)
+test_out=$(go test -timeout=30s ./... 2>&1)
+test_exit=$?
+if [[ $test_exit -ne 0 ]]; then
+  summary=$(echo "$test_out" | grep -E 'FAIL|Error|panic' | head -20)
+  ctx+="go test failed:\n$summary\n"
 fi
 
-if [[ -n "$ERRORS" ]]; then
-  jq -n --arg ctx "$(printf "Issues found after this turn:$ERRORS")" \
-    '{"hookSpecificOutput": {"hookEventName": "Stop", "additionalContext": $ctx}}' || true
+if [[ -n "$ctx" ]]; then
+  jq -n --arg ctx "$ctx" '{
+    "hookSpecificOutput": {
+      "hookEventName": "Stop",
+      "additionalContext": $ctx
+    }
+  }' || true
 fi
 
 exit 0

--- a/.claude/hooks/post-stop-validate.sh
+++ b/.claude/hooks/post-stop-validate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [ -x ./bin/golangci-lint ]; then
+  ./bin/golangci-lint run --fix ./... 2>&1
+fi
+go test -v -timeout=10m ./... 2>&1
+go build ./... 2>&1
+
+exit 0

--- a/.claude/hooks/post-stop-validate.sh
+++ b/.claude/hooks/post-stop-validate.sh
@@ -1,8 +1,40 @@
 #!/bin/bash
+# Stop: batch-format files touched this turn, run lint + tests, report failures.
+# Suite takes ~2s so it's cheap enough to run every turn.
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+TRACKER="$CLAUDE_PROJECT_DIR/.claude/.edited_files"
+ERRORS=""
+
+# Nothing tracked this turn - skip everything
+[[ ! -f "$TRACKER" ]] && exit 0
+
+# Dedup tracked files, filter to existing .go files
+FILES=$(sort -u "$TRACKER" | while read -r f; do [[ -f "$f" ]] && echo "$f"; done)
+rm -f "$TRACKER" 2>/dev/null
+
+[[ -z "$FILES" ]] && exit 0
+
+# 1. Autoformat touched files
+echo "$FILES" | xargs gofmt -w 2>/dev/null || true
+
+# 2. Lint touched files and report remaining offenses
 if [ -x ./bin/golangci-lint ]; then
-  ./bin/golangci-lint run --fix ./... 2>&1
+  LINT_OUTPUT=$(echo "$FILES" | xargs ./bin/golangci-lint run --fix 2>&1)
+  if [ $? -ne 0 ]; then
+    ERRORS="$ERRORS\n## golangci-lint\n$(echo "$LINT_OUTPUT" | head -20)"
+  fi
 fi
-go test -v -timeout=10m ./... 2>&1
-go build ./... 2>&1
+
+# 3. Run full test suite (~2s)
+TEST_OUTPUT=$(go test -timeout=30s ./... 2>&1)
+if [ $? -ne 0 ]; then
+  ERRORS="$ERRORS\n## go test\n$(echo "$TEST_OUTPUT" | grep -E 'FAIL|Error|panic' | head -20)"
+fi
+
+if [[ -n "$ERRORS" ]]; then
+  jq -n --arg ctx "$(printf "Issues found after this turn:$ERRORS")" \
+    '{"hookSpecificOutput": {"hookEventName": "Stop", "additionalContext": $ctx}}' || true
+fi
 
 exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -3,10 +3,11 @@
 # Detects stale lockfiles, uncommitted changes, current branch.
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-# Generate a stable session ID and persist via CLAUDE_ENV_FILE
-# so the edit tracker and stop hook share the same file path
-SESSION_ID="$(date +%s)-$$"
-if [[ -n "$CLAUDE_ENV_FILE" ]]; then
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+# Persist session ID via CLAUDE_ENV_FILE so all hooks share it
+if [[ -n "$SESSION_ID" && -n "$CLAUDE_ENV_FILE" ]]; then
   echo "export CLAUDE_HOOK_SESSION_ID='$SESSION_ID'" >> "$CLAUDE_ENV_FILE"
 fi
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+go mod download 2>&1
+
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -3,17 +3,26 @@
 # Detects stale lockfiles, uncommitted changes, current branch.
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
+# Generate a stable session ID and persist via CLAUDE_ENV_FILE
+# so the edit tracker and stop hook share the same file path
+SESSION_ID="$(date +%s)-$$"
+if [[ -n "$CLAUDE_ENV_FILE" ]]; then
+  echo "export CLAUDE_HOOK_SESSION_ID='$SESSION_ID'" >> "$CLAUDE_ENV_FILE"
+fi
+
 ctx=""
 
-# Check if go.mod is newer than go.sum (deps out of date)
-if [[ -f go.mod && -f go.sum ]]; then
-  if [[ go.mod -nt go.sum ]]; then
-    ctx+="go.mod is newer than go.sum - run go mod tidy\n"
+# Check if go.sum is missing or stale relative to go.mod
+if [[ -f go.mod ]]; then
+  if [[ ! -f go.sum ]]; then
+    ctx+="go.sum missing - run go mod tidy.\n"
+  elif [[ go.mod -nt go.sum ]]; then
+    ctx+="go.mod is newer than go.sum - run go mod tidy.\n"
   fi
 fi
 
-# Check for uncommitted changes
-dirty=$(git diff --name-only 2>/dev/null | head -5)
+# Warn about uncommitted changes
+dirty=$(git status --porcelain 2>/dev/null | head -5)
 if [[ -n "$dirty" ]]; then
   ctx+="Uncommitted changes:\n$dirty\n"
 fi
@@ -24,12 +33,13 @@ if [[ -n "$branch" ]]; then
   ctx+="Branch: $branch\n"
 fi
 
-# Clear stale file tracker from previous session
-rm -f "$CLAUDE_PROJECT_DIR/.claude/.edited_files" 2>/dev/null
-
 if [[ -n "$ctx" ]]; then
-  jq -n --arg ctx "$ctx" \
-    '{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": $ctx}}' || true
+  jq -n --arg ctx "$ctx" '{
+    "hookSpecificOutput": {
+      "hookEventName": "SessionStart",
+      "additionalContext": $ctx
+    }
+  }' || true
 fi
 
 exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,4 +1,35 @@
 #!/bin/bash
-go mod download 2>&1
+# SessionStart: idempotent workspace check (<1s, no network).
+# Detects stale lockfiles, uncommitted changes, current branch.
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+ctx=""
+
+# Check if go.mod is newer than go.sum (deps out of date)
+if [[ -f go.mod && -f go.sum ]]; then
+  if [[ go.mod -nt go.sum ]]; then
+    ctx+="go.mod is newer than go.sum - run go mod tidy\n"
+  fi
+fi
+
+# Check for uncommitted changes
+dirty=$(git diff --name-only 2>/dev/null | head -5)
+if [[ -n "$dirty" ]]; then
+  ctx+="Uncommitted changes:\n$dirty\n"
+fi
+
+# Report current branch
+branch=$(git branch --show-current 2>/dev/null)
+if [[ -n "$branch" ]]; then
+  ctx+="Branch: $branch\n"
+fi
+
+# Clear stale file tracker from previous session
+rm -f "$CLAUDE_PROJECT_DIR/.claude/.edited_files" 2>/dev/null
+
+if [[ -n "$ctx" ]]; then
+  jq -n --arg ctx "$ctx" \
+    '{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": $ctx}}' || true
+fi
 
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,6 +38,18 @@
       "Bash(gh repo view:*)",
       "Bash(gh search:*)"
     ],
+    "ask": [
+      "Bash(gh pr create:*)",
+      "Bash(gh pr edit:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh pr close:*)",
+      "Bash(gh pr ready:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(gh issue create:*)",
+      "Bash(gh issue edit:*)",
+      "Bash(gh issue close:*)",
+      "Bash(gh api:*)"
+    ],
     "deny": [
       "Read(./.env*)"
     ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,11 +43,20 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",
             "command": "./.claude/hooks/post-edit-lint.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/post-commit-lint.sh"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,8 +23,7 @@
       "Bash(git pull:*)",
       "Bash(git cherry-pick:*)",
       "Bash(git reset:*)",
-      "Bash(gh pr:*)",
-      "Bash(gh api:*)"
+      "Bash(gh pr:*)"
     ],
     "deny": [
       "Read(./.env*)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,7 +23,20 @@
       "Bash(git pull:*)",
       "Bash(git cherry-pick:*)",
       "Bash(git reset:*)",
-      "Bash(gh pr:*)"
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr status:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run watch:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh release view:*)",
+      "Bash(gh release list:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh search:*)"
     ],
     "deny": [
       "Read(./.env*)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,18 +38,6 @@
       "Bash(gh repo view:*)",
       "Bash(gh search:*)"
     ],
-    "ask": [
-      "Bash(gh pr create:*)",
-      "Bash(gh pr edit:*)",
-      "Bash(gh pr comment:*)",
-      "Bash(gh pr close:*)",
-      "Bash(gh pr ready:*)",
-      "Bash(gh pr merge:*)",
-      "Bash(gh issue create:*)",
-      "Bash(gh issue edit:*)",
-      "Bash(gh issue close:*)",
-      "Bash(gh api:*)"
-    ],
     "deny": [
       "Read(./.env*)"
     ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,66 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go test:*)",
+      "Bash(go build:*)",
+      "Bash(go mod:*)",
+      "Bash(go vet:*)",
+      "Bash(go version)",
+      "Bash(gofmt:*)",
+      "Bash(./bin/golangci-lint:*)",
+      "Bash(./genmocks.sh)",
+      "Bash(make:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git branch:*)",
+      "Bash(git fetch:*)",
+      "Bash(git stash:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git pull:*)",
+      "Bash(git cherry-pick:*)",
+      "Bash(git reset:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh api:*)"
+    ],
+    "deny": [
+      "Read(./.env*)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/post-edit-lint.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/post-stop-validate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,20 @@
 .idea
 bin/golangci-lint
+
+# AI agent local/ephemeral data
+.claude/plans/
+.claude/memory/
+.claude/worktrees/
+.claude/scheduled-tasks/
+.claude/settings.local.json
+.claude/todos/
+.claude/credentials.json
+CLAUDE.local.md
+.cursor/chat/
+.cursor/composer/
+.cursor/mcp.json
+.windsurf/
+.cline/
+.continue/
+.junie/
+.aider*

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ bin/golangci-lint
 .claude/settings.local.json
 .claude/todos/
 .claude/credentials.json
+.claude/.edited_files
 CLAUDE.local.md
 .cursor/chat/
 .cursor/composer/

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ bin/golangci-lint
 .claude/settings.local.json
 .claude/todos/
 .claude/credentials.json
-.claude/.edited_files
 CLAUDE.local.md
 .cursor/chat/
 .cursor/composer/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,139 @@
+# ChartMogul Go SDK
+
+Go SDK wrapping the ChartMogul API. Single flat package `chartmogul`. Uses `gorequest` for HTTP with automatic retry and exponential backoff via `cenkalti/backoff`.
+
+**Note:** ChartMogul's nginx is incompatible with Go's HTTP/2. Run with `GODEBUG=http2client=0`.
+
+## Commands
+
+```bash
+go test -v -timeout=10m ./...                        # run full test suite
+go test -v -run TestRetrieveCustomer ./...            # run single test
+go test -v -timeout=10m ./integration_tests/...       # run integration tests only
+./bin/golangci-lint run                               # lint
+./genmocks.sh                                         # regenerate mocks
+```
+
+Version is in `version.go`.
+
+## Architecture
+
+### Flat package structure
+
+All source lives in the root package `chartmogul` - no subdirectories for library code. Each API resource gets its own file pair: `<resource>.go` + `<resource>_test.go`.
+
+### Client setup
+
+```go
+type API struct {
+    ApiKey string
+    Client *http.Client   // nil = default; set for tests/VCR
+    Retry  *RetryConfig   // nil = enabled with exponential backoff
+}
+```
+
+Global helpers: `SetURL()` (test overrides), `Setup()` (timeout).
+
+### Generic CRUD helpers (`generic.go`)
+
+All resource methods delegate to shared helpers that handle retry, serialization, and error wrapping:
+
+- `api.create(path, input, output)` - POST
+- `api.retrieve(path, uuid, output)` - GET single (replaces `:uuid` in path)
+- `api.list(path, output, query...)` - GET collection with optional query params
+- `api.update(path, uuid, input, output)` - PATCH
+- `api.putTo(path, uuid, input, output)` - PUT
+- `api.add(path, uuid, input, output)` - POST to sub-resource
+- `api.delete(path, uuid)` - DELETE
+- `api.deleteWhat(path, uuid, input)` - DELETE with query params
+- `api.deleteWithData(path, uuid, input)` - DELETE with body
+- `api.merge(path, input)` - POST merge
+
+Path placeholders (`:uuid`, `:customerUUID`, `:dataSourceUUID`, etc.) are replaced via `strings.Replace` before the request is sent.
+
+### Resource file pattern
+
+Every resource file follows the same layout:
+
+1. **Endpoint constants** at top:
+```go
+const (
+    customersEndpoint       = "customers"
+    singleCustomerEndpoint  = "customers/:uuid"
+)
+```
+
+2. **Type definitions** with JSON tags:
+   - `<Resource>` - API response model (GET/list result)
+   - `New<Resource>` - creation input (POST body)
+   - `Update<Resource>` - update input (PATCH body), uses `*string`/`*bool` pointers for nullable fields
+   - `<Resource>s` - list response wrapper with `Pagination` embed
+   - `List<Resource>sParams` / `Filter<Resource>Params` - query parameter structs
+
+3. **API methods** on `API` struct, delegating to generic helpers:
+```go
+func (api API) CreateCustomer(newCustomer *NewCustomer) (*Customer, error) {
+    result := &Customer{}
+    return result, api.create(customersEndpoint, newCustomer, result)
+}
+```
+
+### IApi interface (`chartmogul.go`)
+
+All public API methods are declared in the `IApi` interface. This enables mock generation for consumer tests. When adding a new endpoint, add the method signature here.
+
+### Mocks (`mock_chartmogul/`)
+
+Auto-generated via `./genmocks.sh` using `golang/mock`. Never edit manually.
+
+### Retry and error handling
+
+- Retries on: 429, 500, 502, 503, 504, and network errors (i/o timeout, `net.OpError`)
+- Exponential backoff via `cenkalti/backoff/v3`
+- Errors wrapped with `pkg/errors`
+- `httpError` exposes `StatusCode()` and `Response()` via `HTTPError` interface
+- `Errors` type (map) has helpers: `IsAlreadyExists()`, `IsInvoiceAndTransactionAlreadyExist()`, etc.
+
+### Pagination
+
+Two patterns embedded into list response structs:
+- `Pagination` - cursor-based (`HasMore`, `Cursor`)
+- `MetricsPagination` - page-based (`CurrentPage`, `TotalPages`)
+
+## Testing
+
+### Unit tests (root `*_test.go`)
+
+- Standard `testing` package with `httptest.NewServer` for HTTP mocking
+- Inline JSON constants as fixtures (e.g., `const oneInvoiceExample = ...`)
+- Pattern: spin up mock server, call `SetURL(server.URL + "/v/%v")`, exercise the API method, assert fields
+- Use `reflect.DeepEqual` or `go-test/deep` for struct comparison
+- `spew.Dump` for debug output
+- Live API tests gated behind `-cm` flag (skipped by default)
+
+### Integration tests (`integration_tests/`)
+
+- VCR-based via `dnaeon/go-vcr`: records/replays HTTP interactions as YAML cassettes in `integration_tests/fixtures/`
+- Authorization headers filtered out of recordings
+- Skipped in short mode (`-short` flag)
+
+### Adding a new endpoint
+
+1. Create `<resource>.go` with endpoint constants, types, and API methods
+2. Create `<resource>_test.go` with inline JSON fixtures and httptest-based tests
+3. Add method signatures to `IApi` interface in `chartmogul.go`
+4. Run `./genmocks.sh` to regenerate mocks
+5. Optionally add integration tests in `integration_tests/` with VCR fixture
+
+## Code style
+
+- Go conventions: `PascalCase` exports, `camelCase` locals, `UPPER_CASE` not used for constants
+- Endpoint constants: `camelCase` + `Endpoint` suffix (e.g., `singleCustomerEndpoint`)
+- JSON tags: `snake_case` matching the API, with `omitempty` on optional fields
+- Pointer types (`*string`, `*bool`) in update structs to distinguish zero-value from absent
+- Non-pointer receiver on API methods: `func (api API) CreateCustomer(...)`
+- Linting: golangci-lint with config in `.golangci.yml`
+
+## CI
+
+GitHub Actions on push/PR to main. Go version matrix: 1.21, 1.22, 1.23, 1.24. Runs `make test` + golangci-lint + CodeClimate coverage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` as single source of truth for AI coding assistant context (Cursor, Copilot, Windsurf, Codex, Cline all read it natively)
- Adds `CLAUDE.md` as a thin `@AGENTS.md` import for Claude Code
- Adds `.claude/` with permissions and four hooks tuned for speed
- Adds `.gitignore` rules for ephemeral AI tool data while keeping shared config tracked

## Hooks

| Hook | Event | Budget | What it does |
|------|-------|--------|-------------|
| `session-start.sh` | SessionStart | <1s | Generates session-scoped tracker ID via `CLAUDE_ENV_FILE`. Reports git branch, dirty files (staged + unstaged), lockfile staleness (`go.mod -nt go.sum`) or missing `go.sum`. Local-only, no network. |
| `post-edit-lint.sh` | PostToolUse (Edit/Write/MultiEdit) | <50ms | Records edited `.go` file path to a session-scoped tracker in `/tmp/`. Deduplicates inline with `sort -u`. Skips `vendor/`, `mock_chartmogul/`, `coverage/`. No formatting. |
| `post-commit-lint.sh` | PostToolUse (Bash) | ~3s | Fires only on `git commit` commands. Runs `golangci-lint` via `xargs` on `.go` files in the just-created commit. Reports failures as structured JSON context for the next prompt. |
| `post-stop-validate.sh` | Stop | ~5s | Batch-formats tracked files with `gofmt -w`, then runs `golangci-lint --fix` on touched files, then runs `go test` unconditionally (~2s). Reports failures as structured JSON context for the next prompt. Silent on clean runs. |

## Design decisions
- **Edit path is fast** - no formatting or linting on individual edits; batched in Stop hook instead
- **Tests run unconditionally in Stop** - suite runs in ~2s so the cost is negligible; catches regressions regardless of how code changed (Edit, Bash, file deletion)
- **Session-scoped tracker** - tracker filename includes a session ID (via `CLAUDE_ENV_FILE`) so concurrent sessions on the same machine don't collide
- **No blocking hooks** - failures inform the next prompt rather than forcing a retry loop
- **SessionStart is local-only** - detects problems (stale/missing `go.sum`, uncommitted changes) but does not fix them; the agent acts on warnings
- **Aligned with Ruby SDK** - same hook pipeline pattern (record-on-edit, batch-in-stop), same `CLAUDE_ENV_FILE` session ID mechanism, same structured `jq` output format

## Test plan
- Open the repo in Claude Code and verify `CLAUDE.md` resolves the `@AGENTS.md` import
- Confirm `.claude/settings.local.json` is gitignored but `.claude/settings.json` is tracked
- Start a session and confirm `session-start.sh` emits branch, uncommitted changes, and exports `CLAUDE_HOOK_SESSION_ID`
- Edit a `.go` file and verify the edit completes instantly (no formatting delay)
- Edit a file in `mock_chartmogul/` and verify it is skipped by the tracker
- After the turn ends, verify the stop hook ran `gofmt`, `golangci-lint`, and `go test` (check for structured output on failure)
- End a turn without editing any files and confirm tests still run unconditionally
- Run `git commit` and confirm `post-commit-lint.sh` lints the committed files