### PR TITLE
Add automated release script and test gate on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: ${{ matrix.go-version }}
+          cache: false
 
       - name: Run tests
         run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,18 +4,40 @@ on:
   push:
     tags: ['v*']
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
-  release:
+  test:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        go-version: ['1.21', '1.22', '1.23', '1.24']
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Run tests
+        run: make test
+
+  release:
+    needs: test
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: gh release create "$GITHUB_REF_NAME" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
 name: Run specs and generate Code Climate report
 on:
   push:
-    branches: [ main, v4 ]
+    branches: [ main, 'v*' ]
   pull_request:
-    branches: [ main, v4 ]
+    branches: [ main, 'v*' ]
 permissions:
   contents: read
   pull-requests: read
@@ -53,7 +53,8 @@ jobs:
             echo "mode: set" > c.out
             grep -h -v "^mode:" ./*.cover >> c.out
             rm -f *.cover
-            sed -i 's#^github.com/chartmogul/chartmogul-go/v4/##g' c.out
+            MODULE=$(go list -m)
+            sed -i "s#^${MODULE}/##g" c.out
   linter:
     runs-on: ubuntu-24.04
     steps:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><code>chartmogul-go</code> provides convenient Golang bindings for <a href="https://dev.chartmogul.com">ChartMogul's API</a>.</p>
 <p align="center">
-  <a href="https://github.com/chartmogul/chartmogul-go/tree/v2"><img src="https://github.com/chartmogul/chartmogul-go/actions/workflows/test.yml/badge.svg?branch=v2" alt="Build Status"/></a>
+  <a href="https://github.com/chartmogul/chartmogul-go/actions/workflows/test.yml"><img src="https://github.com/chartmogul/chartmogul-go/actions/workflows/test.yml/badge.svg" alt="Build Status"/></a>
 </p>
 <hr>
 
@@ -38,10 +38,10 @@
 This library requires Go 1.21 or above.
 
 ```sh
-go get github.com/chartmogul/chartmogul-go/v4@v4.11.0
+go get github.com/chartmogul/chartmogul-go/v4
 ```
 
-We recommend pinning to a specific version as shown above. Go modules will record the exact version and cryptographic checksums in your `go.mod` and `go.sum` files.
+Go modules will record the exact version and cryptographic checksums in your `go.mod` and `go.sum` files.
 
 Always commit your `go.sum` file to version control. It contains cryptographic hashes verified against the [Go checksum database](https://sum.golang.org), ensuring the code you depend on has not been tampered with.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 |
 <b><a href="#contributing">Contributing</a></b>
 |
+<b><a href="#releasing">Releasing</a></b>
+|
 <b><a href="#security">Security</a></b>
 |
 <b><a href="#license">License</a></b>
@@ -375,6 +377,10 @@ To work on the library:
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/chartmogul/chartmogul-go.
+
+## Releasing
+
+See [RELEASING.md](RELEASING.md) for the full release process.
 
 ## Security
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,27 +3,35 @@
 ## Prerequisites
 
 - You must have push access to the repository
+- `git`, `gh`, and `jq` must be installed
 - Tags matching `v*` are protected by GitHub tag protection rulesets
 - Releases are immutable once published (GitHub repository setting)
 
 ## Release Process
 
-1. Ensure all changes are merged to the `v4` branch
-2. Ensure CI is green on the `v4` branch
-3. Create and push a version tag:
-   ```sh
-   git tag v4.X.Y
-   git push origin v4.X.Y
-   ```
-4. The [release workflow](.github/workflows/release.yml) will automatically create a GitHub Release with auto-generated release notes
-5. Verify the release appears at https://github.com/chartmogul/chartmogul-go/releases
-6. The Go module proxy (proxy.golang.org) will cache the new version on first fetch
+Run the release script from the repository root:
+
+```sh
+bin/release.sh <patch|minor|major>
+```
+
+The script will:
+
+1. Verify prerequisites and that CI is green on `v4`
+2. Show any open PRs targeting `v4` and ask for confirmation
+3. Show PRs merged since the last tag and ask for confirmation
+4. Calculate the new version based on the last tag
+5. Tag the latest commit on `v4` and push the tag
+6. Wait for the [release workflow](.github/workflows/release.yml) to complete, which will:
+   - Run the full test suite across Go 1.21, 1.22, 1.23, and 1.24
+   - Create a GitHub Release with auto-generated release notes
+7. Print links to the GitHub Release and pkg.go.dev
 
 ## Changelog
 
 Release notes are auto-generated from merged PR titles by the [release workflow](.github/workflows/release.yml). To ensure useful changelogs:
 
-- Use clear, descriptive PR titles (e.g., "Add External ID field to Contact model")
+- Use clear, descriptive PR titles (e.g., "Add bulk import endpoints")
 - Prefix breaking changes with `BREAKING:` so they stand out in release notes
 - After the release is created, review and edit the notes on the [Releases page](https://github.com/chartmogul/chartmogul-go/releases) if needed
 
@@ -32,8 +40,8 @@ Release notes are auto-generated from merged PR titles by the [release workflow]
 For pre-release versions, use a semver pre-release suffix:
 
 ```sh
-git tag v4.X.Y-rc1
-git push origin v4.X.Y-rc1
+git tag vX.Y.Z-rc1
+git push origin vX.Y.Z-rc1
 ```
 
 These will be automatically marked as pre-releases on GitHub.
@@ -45,21 +53,22 @@ These will be automatically marked as pre-releases on GitHub.
 - **Immutable releases**: Once a GitHub Release is published, its tag cannot be moved or deleted, and release assets cannot be modified
 - **Tag protection rulesets**: `v*` tags cannot be deleted or force-pushed
 
-### Go Module Proxy
+### Go Module Security
 
-- [proxy.golang.org](https://proxy.golang.org) caches module versions permanently on first fetch
-- [sum.golang.org](https://sum.golang.org) records cryptographic hashes in a tamper-evident Merkle tree
-- Users running `go get` with default settings automatically verify against both services
+- Go modules are fetched directly from the Git repository and verified against the [Go checksum database](https://sum.golang.org) - there is no separate package registry to compromise
+- The `go.sum` file in downstream projects contains cryptographic hashes (SHA-256) for all dependencies, ensuring reproducible and tamper-evident builds
+- The checksum database provides a global, append-only transparency log that prevents after-the-fact modification of published module versions
 
 ### What This Protects Against
 
 - A compromised maintainer account cannot modify or delete existing releases
 - Tags cannot be moved to point to different commits after publication
-- The Go checksum database provides an independent verification layer beyond GitHub
+- The Go checksum database provides an independent immutability layer beyond GitHub - once a version is fetched by any user, its hash is recorded in the transparency log and cannot be changed
+- Unlike package registries that rely on re-upload prevention alone, Go's checksum database cryptographically verifies that every user gets identical module contents
 
 ### Repository Settings (Admin)
 
 These settings must be configured by a repository admin:
 
 1. **Immutable Releases**: Settings > General > Releases > Enable "Immutable releases"
-2. **Tag Protection Ruleset**: Settings > Rules > Rulesets > New ruleset targeting tags matching `v*` with deletion and force-push prevention
+2. **Tag Protection Ruleset**: Settings > Rules > Rulesets > New ruleset targeting tags matching `v*` with deletion, force-push, and update prevention

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,7 +17,7 @@ bin/release.sh <patch|minor|major>
 
 The script will:
 
-1. Determine the target branch from the last tag: patch/minor releases land on the current `v{major}` branch, major releases land on `v{major+1}` (which must already exist with an updated module path in `go.mod`)
+1. Determine the target branch from the last tag: patch/minor releases land on the current `v{major}` branch, major releases land on `v{major+1}`. If the `v{major+1}` branch does not yet exist, the script opens a [setup PR](#major-releases) that updates the module path and stops - merge that PR, complete the admin checklist in its description, then re-run `bin/release.sh major`
 2. Verify prerequisites and that CI is green on the target branch
 3. Show any open PRs targeting that branch and ask for confirmation
 4. Show PRs merged since the last tag and ask for confirmation
@@ -35,6 +35,26 @@ Release notes are auto-generated from merged PR titles by the [release workflow]
 - Use clear, descriptive PR titles (e.g., "Add bulk import endpoints")
 - Prefix breaking changes with `BREAKING:` so they stand out in release notes
 - After the release is created, review and edit the notes on the [Releases page](https://github.com/chartmogul/chartmogul-go/releases) if needed
+
+## Major Releases
+
+Go encodes the major version in the module path (e.g. `github.com/chartmogul/chartmogul-go/v5`), so a major bump requires a new `v{major+1}` branch with an updated `go.mod`.
+
+Running `bin/release.sh major` when that branch does not exist will:
+
+1. Push a new `v{major+1}` branch from the current major branch
+2. Open a setup PR that rewrites the module path in `go.mod` and all `.go`/`.md` files
+3. Exit with a pointer to the PR
+
+The setup PR description contains a checklist of admin tasks that must be completed after merge:
+
+- Switch the default branch to `v{major+1}`
+- Update `.github/workflows/test.yml` so `branches` filters include `v{major+1}`
+- Extend the branch protection ruleset to cover `v{major+1}`
+- Verify the `v*` tag ruleset still applies
+- Update README install snippet and badges
+
+Once the setup PR is merged and the admin tasks are done, re-run `bin/release.sh major` to tag `v{major+1}.0.0`.
 
 ## Pre-release Versions
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,7 +51,6 @@ The setup PR description contains a checklist of admin tasks that must be comple
 - Switch the default branch to `v{major+1}`
 - Extend the branch protection ruleset to cover `v{major+1}` (the test workflow already runs on any `v*` branch)
 - Verify the `v*` tag ruleset still applies
-- Update README install snippet and badges
 
 Once the setup PR is merged and the admin tasks are done, re-run `bin/release.sh major` to tag `v{major+1}.0.0`.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,8 +49,7 @@ Running `bin/release.sh major` when that branch does not exist will:
 The setup PR description contains a checklist of admin tasks that must be completed after merge:
 
 - Switch the default branch to `v{major+1}`
-- Update `.github/workflows/test.yml` so `branches` filters include `v{major+1}`
-- Extend the branch protection ruleset to cover `v{major+1}`
+- Extend the branch protection ruleset to cover `v{major+1}` (the test workflow already runs on any `v*` branch)
 - Verify the `v*` tag ruleset still applies
 - Update README install snippet and badges
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,15 +17,16 @@ bin/release.sh <patch|minor|major>
 
 The script will:
 
-1. Verify prerequisites and that CI is green on `v4`
-2. Show any open PRs targeting `v4` and ask for confirmation
-3. Show PRs merged since the last tag and ask for confirmation
-4. Calculate the new version based on the last tag
-5. Tag the latest commit on `v4` and push the tag
-6. Wait for the [release workflow](.github/workflows/release.yml) to complete, which will:
+1. Determine the target branch from the last tag: patch/minor releases land on the current `v{major}` branch, major releases land on `v{major+1}` (which must already exist with an updated module path in `go.mod`)
+2. Verify prerequisites and that CI is green on the target branch
+3. Show any open PRs targeting that branch and ask for confirmation
+4. Show PRs merged since the last tag and ask for confirmation
+5. Calculate the new version based on the last tag
+6. Tag the latest commit on the target branch and push the tag
+7. Wait for the [release workflow](.github/workflows/release.yml) to complete, which will:
    - Run the full test suite across Go 1.21, 1.22, 1.23, and 1.24
    - Create a GitHub Release with auto-generated release notes
-7. Print links to the GitHub Release and pkg.go.dev
+8. Print links to the GitHub Release and pkg.go.dev
 
 ## Changelog
 

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEFAULT_BRANCH="v4"
-
 # --- Usage -------------------------------------------------------------------
 
 usage() {
@@ -28,6 +26,39 @@ for cmd in git gh jq; do
 done
 
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+# --- Determine release branch ------------------------------------------------
+#
+# Go module versioning uses major-version branches (v4, v5, ...). Patch and
+# minor releases land on the current major branch; major releases land on a
+# new v{major+1} branch, which must already exist (it requires a module path
+# change in go.mod and so cannot be created by this script).
+
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [[ -z "$LAST_TAG" ]]; then
+  echo "Error: No existing tag found - cannot determine current major version." >&2
+  exit 1
+fi
+
+CURRENT_VERSION="${LAST_TAG#v}"
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+if [[ "$BUMP_TYPE" == "major" ]]; then
+  TARGET_MAJOR=$((MAJOR + 1))
+else
+  TARGET_MAJOR="$MAJOR"
+fi
+
+DEFAULT_BRANCH="v${TARGET_MAJOR}"
+
+if ! git ls-remote --exit-code --heads origin "$DEFAULT_BRANCH" &>/dev/null; then
+  echo "Error: Branch '${DEFAULT_BRANCH}' does not exist on origin." >&2
+  if [[ "$BUMP_TYPE" == "major" ]]; then
+    echo "  For a major release, create the '${DEFAULT_BRANCH}' branch first with the updated" >&2
+    echo "  module path in go.mod (github.com/chartmogul/chartmogul-go/${DEFAULT_BRANCH})." >&2
+  fi
+  exit 1
+fi
 
 # --- Check CI is green -------------------------------------------------------
 
@@ -62,16 +93,9 @@ fi
 
 # --- Show PRs included in this release ----------------------------------------
 
-LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-if [[ -n "$LAST_TAG" ]]; then
-  echo ""
-  echo "PRs merged since ${LAST_TAG}:"
-  MERGED_PRS=$(gh pr list --base "$DEFAULT_BRANCH" --state merged --search "merged:>=$(git log -1 --format=%aI "$LAST_TAG")" --json number,title,url)
-else
-  echo ""
-  echo "PRs merged (no previous tag found, showing recent):"
-  MERGED_PRS=$(gh pr list --base "$DEFAULT_BRANCH" --state merged --limit 10 --json number,title,url)
-fi
+echo ""
+echo "PRs merged since ${LAST_TAG}:"
+MERGED_PRS=$(gh pr list --base "$DEFAULT_BRANCH" --state merged --search "merged:>=$(git log -1 --format=%aI "$LAST_TAG")" --json number,title,url)
 
 MERGED_COUNT=$(echo "$MERGED_PRS" | jq 'length')
 if [[ "$MERGED_COUNT" -eq 0 ]]; then
@@ -89,11 +113,8 @@ fi
 
 # --- Calculate new version ----------------------------------------------------
 
-CURRENT_VERSION="${LAST_TAG#v}"
-IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-
 case "$BUMP_TYPE" in
-  major) NEW_VERSION="$((MAJOR + 1)).0.0" ;;
+  major) NEW_VERSION="${TARGET_MAJOR}.0.0" ;;
   minor) NEW_VERSION="${MAJOR}.$((MINOR + 1)).0" ;;
   patch) NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
 esac

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -50,14 +50,123 @@ else
 fi
 
 DEFAULT_BRANCH="v${TARGET_MAJOR}"
+SOURCE_BRANCH="v${MAJOR}"
+
+# --- Bootstrap new major branch (one-time setup for major releases) ----------
+#
+# A major release targets a new v{N+1} branch, which must have the module path
+# in go.mod and all Go imports updated. If that branch doesn't exist yet, the
+# script opens a setup PR with those changes and stops - the PR must be merged
+# and the branch made the default before a tag can be pushed.
 
 if ! git ls-remote --exit-code --heads origin "$DEFAULT_BRANCH" &>/dev/null; then
-  echo "Error: Branch '${DEFAULT_BRANCH}' does not exist on origin." >&2
-  if [[ "$BUMP_TYPE" == "major" ]]; then
-    echo "  For a major release, create the '${DEFAULT_BRANCH}' branch first with the updated" >&2
-    echo "  module path in go.mod (github.com/chartmogul/chartmogul-go/${DEFAULT_BRANCH})." >&2
+  if [[ "$BUMP_TYPE" != "major" ]]; then
+    echo "Error: Branch '${DEFAULT_BRANCH}' does not exist on origin." >&2
+    exit 1
   fi
-  exit 1
+
+  echo ""
+  echo "Branch '${DEFAULT_BRANCH}' does not exist. A major release requires a new"
+  echo "major-version branch with the module path updated."
+  echo ""
+  echo "This script will:"
+  echo "  1. Push a new '${DEFAULT_BRANCH}' branch from origin/${SOURCE_BRANCH}"
+  echo "  2. Open a PR that updates the module path from /${SOURCE_BRANCH} to /${DEFAULT_BRANCH} in go.mod and all .go/.md files"
+  echo "  3. Exit. You then need to merge the PR, have admins apply branch protections, make '${DEFAULT_BRANCH}' the default branch, then re-run 'bin/release.sh major'."
+  echo ""
+  read -rp "Proceed? [y/N] " CONFIRM
+  if [[ ! "$CONFIRM" =~ ^[yY]$ ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+
+  STASHED=false
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    git stash --include-untracked --quiet
+    STASHED=true
+  fi
+  restore_stash() {
+    if [[ "$STASHED" == true ]]; then
+      git stash pop --quiet 2>/dev/null || true
+      STASHED=false
+    fi
+  }
+  trap restore_stash EXIT
+
+  git fetch origin "$SOURCE_BRANCH"
+
+  # Create the new major branch on origin, pointing at source HEAD.
+  git push origin "origin/${SOURCE_BRANCH}:refs/heads/${DEFAULT_BRANCH}"
+  echo "Created '${DEFAULT_BRANCH}' on origin."
+
+  SETUP_BRANCH="setup/${DEFAULT_BRANCH}-module-path"
+  git checkout -B "$SETUP_BRANCH" "origin/${SOURCE_BRANCH}"
+
+  OLD_PATH="github.com/chartmogul/chartmogul-go/${SOURCE_BRANCH}"
+  NEW_PATH="github.com/chartmogul/chartmogul-go/${DEFAULT_BRANCH}"
+
+  # Update module path in go.mod and all references in .go / .md files.
+  # Using find with -print0 so paths with spaces are handled; LC_ALL=C keeps sed portable.
+  while IFS= read -r -d '' f; do
+    LC_ALL=C sed -i.bak "s|${OLD_PATH}|${NEW_PATH}|g" "$f" && rm -f "${f}.bak"
+  done < <(find . \( -name "*.go" -o -name "*.md" -o -name "go.mod" \) -not -path "./vendor/*" -not -path "./.git/*" -print0)
+
+  if git diff --quiet; then
+    echo "Error: No references to '${OLD_PATH}' found - nothing to update." >&2
+    exit 1
+  fi
+
+  git add -A
+  git commit -m "Update module path from /${SOURCE_BRANCH} to /${DEFAULT_BRANCH}"
+  git push -u origin "$SETUP_BRANCH"
+
+  PR_BODY=$(cat <<EOF
+## Summary
+
+Bootstrap the \`${DEFAULT_BRANCH}\` branch for the upcoming ${DEFAULT_BRANCH}.0.0 major release. Updates the module path from \`${OLD_PATH}\` to \`${NEW_PATH}\` in \`go.mod\` and all Go imports and documentation references.
+
+This PR is opened automatically by \`bin/release.sh major\` when the \`${DEFAULT_BRANCH}\` branch does not yet exist.
+
+## Admin checklist (to be done after merge)
+
+- [ ] **Update default branch**: Settings > General > Default branch > switch from \`${SOURCE_BRANCH}\` to \`${DEFAULT_BRANCH}\`
+- [ ] **Update test workflow**: edit \`.github/workflows/test.yml\` so \`branches\` filters include \`${DEFAULT_BRANCH}\` (and drop \`${SOURCE_BRANCH}\` when no longer maintained)
+- [ ] **Branch protection ruleset**: Settings > Rules > Rulesets > add/extend ruleset to target \`${DEFAULT_BRANCH}\` with require-PR, require-status-checks, force-push prevention, and deletion prevention
+- [ ] **Tag protection ruleset**: confirm the existing \`v*\` tag ruleset still applies (it should, but verify after the default branch change)
+- [ ] **pkg.go.dev**: after the first \`${DEFAULT_BRANCH}.0.0\` tag is pushed, visit https://pkg.go.dev/${NEW_PATH} to trigger indexing
+- [ ] **README**: update install snippet and any badges that reference \`${SOURCE_BRANCH}\`
+
+## Next steps
+
+After this PR is merged and the admin checklist above is complete, re-run:
+
+\`\`\`sh
+bin/release.sh major
+\`\`\`
+
+which will tag \`${DEFAULT_BRANCH}.0.0\` on the \`${DEFAULT_BRANCH}\` branch.
+EOF
+)
+
+  PR_URL=$(gh pr create \
+    --base "$DEFAULT_BRANCH" \
+    --head "$SETUP_BRANCH" \
+    --title "Update module path to /${DEFAULT_BRANCH}" \
+    --body "$PR_BODY" \
+    | tail -1)
+
+  echo ""
+  echo "Setup PR created: ${PR_URL}"
+  echo ""
+  echo "Next steps:"
+  echo "  1. Review and merge the PR"
+  echo "  2. Complete the admin checklist in the PR description"
+  echo "  3. Re-run 'bin/release.sh major' to tag ${DEFAULT_BRANCH}.0.0"
+
+  git checkout "$SOURCE_BRANCH" 2>/dev/null || true
+  restore_stash
+  trap - EXIT
+  exit 0
 fi
 
 # --- Check CI is green -------------------------------------------------------

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -133,7 +133,6 @@ This PR is opened automatically by \`bin/release.sh major\` when the \`${DEFAULT
 - [ ] **Branch protection ruleset**: Settings > Rules > Rulesets > add/extend ruleset to target \`${DEFAULT_BRANCH}\` with require-PR, require-status-checks, force-push prevention, and deletion prevention
 - [ ] **Tag protection ruleset**: confirm the existing \`v*\` tag ruleset still applies (it should, but verify after the default branch change)
 - [ ] **pkg.go.dev**: after the first \`${DEFAULT_BRANCH}.0.0\` tag is pushed, visit https://pkg.go.dev/${NEW_PATH} to trigger indexing
-- [ ] **README**: update install snippet and any badges that reference \`${SOURCE_BRANCH}\`
 
 ## Next steps
 

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -130,7 +130,6 @@ This PR is opened automatically by \`bin/release.sh major\` when the \`${DEFAULT
 ## Admin checklist (to be done after merge)
 
 - [ ] **Update default branch**: Settings > General > Default branch > switch from \`${SOURCE_BRANCH}\` to \`${DEFAULT_BRANCH}\`
-- [ ] **Update test workflow**: edit \`.github/workflows/test.yml\` so \`branches\` filters include \`${DEFAULT_BRANCH}\` (and drop \`${SOURCE_BRANCH}\` when no longer maintained)
 - [ ] **Branch protection ruleset**: Settings > Rules > Rulesets > add/extend ruleset to target \`${DEFAULT_BRANCH}\` with require-PR, require-status-checks, force-push prevention, and deletion prevention
 - [ ] **Tag protection ruleset**: confirm the existing \`v*\` tag ruleset still applies (it should, but verify after the default branch change)
 - [ ] **pkg.go.dev**: after the first \`${DEFAULT_BRANCH}.0.0\` tag is pushed, visit https://pkg.go.dev/${NEW_PATH} to trigger indexing

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_BRANCH="v4"
+
+# --- Usage -------------------------------------------------------------------
+
+usage() {
+  echo "Usage: bin/release.sh <patch|minor|major>"
+  exit 1
+}
+
+[[ $# -eq 1 ]] || usage
+
+BUMP_TYPE="$1"
+case "$BUMP_TYPE" in
+  patch|minor|major) ;;
+  *) usage ;;
+esac
+
+# --- Prerequisites -----------------------------------------------------------
+
+for cmd in git gh jq; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "Error: '$cmd' is required but not found on PATH." >&2
+    exit 1
+  fi
+done
+
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+# --- Check CI is green -------------------------------------------------------
+
+echo "Checking CI status on ${DEFAULT_BRANCH}..."
+LAST_RUN=$(gh run list --branch "$DEFAULT_BRANCH" --workflow test.yml --limit 1 --json conclusion,url)
+CONCLUSION=$(echo "$LAST_RUN" | jq -r '.[0].conclusion // empty')
+RUN_URL=$(echo "$LAST_RUN" | jq -r '.[0].url // empty')
+
+if [[ "$CONCLUSION" != "success" ]]; then
+  echo "Error: Latest CI run on ${DEFAULT_BRANCH} is not green (status: ${CONCLUSION:-unknown})." >&2
+  [[ -n "$RUN_URL" ]] && echo "  $RUN_URL" >&2
+  exit 1
+fi
+echo "CI is green."
+
+# --- Show open PRs -----------------------------------------------------------
+
+OPEN_PRS=$(gh pr list --base "$DEFAULT_BRANCH" --json number,title,url)
+PR_COUNT=$(echo "$OPEN_PRS" | jq 'length')
+
+if [[ "$PR_COUNT" -gt 0 ]]; then
+  echo ""
+  echo "There are $PR_COUNT open PR(s) targeting ${DEFAULT_BRANCH}:"
+  echo "$OPEN_PRS" | jq -r '.[] | "  #\(.number) \(.title)\n    \(.url)"'
+  echo ""
+  read -rp "Continue releasing? [y/N] " CONFIRM
+  if [[ ! "$CONFIRM" =~ ^[yY]$ ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+fi
+
+# --- Show PRs included in this release ----------------------------------------
+
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [[ -n "$LAST_TAG" ]]; then
+  echo ""
+  echo "PRs merged since ${LAST_TAG}:"
+  MERGED_PRS=$(gh pr list --base "$DEFAULT_BRANCH" --state merged --search "merged:>=$(git log -1 --format=%aI "$LAST_TAG")" --json number,title,url)
+else
+  echo ""
+  echo "PRs merged (no previous tag found, showing recent):"
+  MERGED_PRS=$(gh pr list --base "$DEFAULT_BRANCH" --state merged --limit 10 --json number,title,url)
+fi
+
+MERGED_COUNT=$(echo "$MERGED_PRS" | jq 'length')
+if [[ "$MERGED_COUNT" -eq 0 ]]; then
+  echo "  (none)"
+else
+  echo "$MERGED_PRS" | jq -r '.[] | "  #\(.number) \(.title)\n    \(.url)"'
+fi
+
+echo ""
+read -rp "Release these changes as ${BUMP_TYPE}? [y/N] " CONFIRM
+if [[ ! "$CONFIRM" =~ ^[yY]$ ]]; then
+  echo "Aborted."
+  exit 0
+fi
+
+# --- Calculate new version ----------------------------------------------------
+
+CURRENT_VERSION="${LAST_TAG#v}"
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+case "$BUMP_TYPE" in
+  major) NEW_VERSION="$((MAJOR + 1)).0.0" ;;
+  minor) NEW_VERSION="${MAJOR}.$((MINOR + 1)).0" ;;
+  patch) NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+esac
+
+TAG="v${NEW_VERSION}"
+
+echo ""
+echo "Tagging: ${LAST_TAG} -> ${TAG}"
+
+# --- Ensure we're on latest default branch ------------------------------------
+
+git checkout "$DEFAULT_BRANCH"
+git pull
+
+# --- Tag and push -------------------------------------------------------------
+
+git tag "$TAG"
+git push origin "$TAG"
+
+echo "Tag ${TAG} pushed."
+echo "Waiting for release workflow..."
+
+# --- Poll for release CI ------------------------------------------------------
+
+interrupt_ci_wait() {
+  echo ""
+  echo "Interrupted. The tag ${TAG} has been pushed and the release workflow is running."
+  echo "  Workflow: https://github.com/${REPO}/actions/workflows/release.yml"
+  echo "  GitHub:   https://github.com/${REPO}/releases/tag/${TAG}"
+  exit 0
+}
+
+trap interrupt_ci_wait INT
+
+sleep 5 # give GitHub a moment to register the run
+while true; do
+  RUN=$(gh run list --branch "$TAG" --workflow release.yml --limit 1 --json status,conclusion,url)
+  STATUS=$(echo "$RUN" | jq -r '.[0].status // empty')
+  RUN_CONCLUSION=$(echo "$RUN" | jq -r '.[0].conclusion // empty')
+  RELEASE_RUN_URL=$(echo "$RUN" | jq -r '.[0].url // empty')
+
+  if [[ "$STATUS" == "completed" ]]; then
+    echo ""
+    if [[ "$RUN_CONCLUSION" == "success" ]]; then
+      echo "Release workflow completed successfully."
+    else
+      echo "Release workflow finished with status: ${RUN_CONCLUSION}" >&2
+    fi
+    [[ -n "$RELEASE_RUN_URL" ]] && echo "  $RELEASE_RUN_URL"
+    break
+  fi
+  printf "."
+  sleep 10
+done
+
+trap - INT
+
+# --- Summary ------------------------------------------------------------------
+
+echo ""
+echo "Release ${TAG} complete!"
+echo "  GitHub:  https://github.com/${REPO}/releases/tag/${TAG}"
+echo "  pkg.go:  https://pkg.go.dev/github.com/${REPO}/${DEFAULT_BRANCH}@${TAG}"


### PR DESCRIPTION
## Summary
- Update `.github/workflows/release.yml` to run the full test matrix (Go 1.21-1.24) before creating a GitHub Release - previously the release was created directly on tag push with no test gate
- Update `.github/workflows/test.yml` to run on any `v*` branch (not just `v4`) and derive the module path from `go list -m` so future major branches work without edits
- Make `README.md` version-agnostic: drop the pinned version from the `go get` snippet and the branch query string from the build badge, so a major bump needs no README edits beyond the module-path rewrite the setup PR already does
- Add `bin/release.sh` to automate the entire release flow end-to-end, including bootstrapping a new major-version branch
- Update `RELEASING.md` to reference the release script, document the major-release flow, and expand the security section with Go checksum database details
- Add Releasing section to `README.md` linking to `RELEASING.md`, add Releasing to TOC

## `bin/release.sh`

```sh
bin/release.sh <patch|minor|major>
```

The script automates the full release process:

1. Checks prerequisites (`git`, `gh`, `jq`)
2. Determines the target branch from the last tag - patch/minor stay on the current `v{major}` branch, major targets `v{major+1}`
3. If the target branch does not yet exist (major release bootstrap - see below), pushes it, opens a setup PR, and exits
4. Verifies CI is green on the target branch, exits with a link to the failed run if not
5. Lists open PRs targeting the target branch and asks for confirmation to continue
6. Lists PRs merged since the last tag (what's being released) and asks for confirmation to continue
7. Tags the latest commit on the target branch and pushes the tag
8. Polls for the release workflow to complete (every 10s)
9. Prints links to the GitHub Release and pkg.go.dev

Unlike the Node SDK version there is no `package.json` to bump (Go module versions are determined entirely by git tags), so for patch/minor releases the script skips the PR creation/merge/polling step and tags directly.

If interrupted (Ctrl-C) during the CI polling step, it prints the remaining links needed to check the release status manually.

### Major-release bootstrap

Go encodes the major version in the module path (`github.com/chartmogul/chartmogul-go/v5`), so bumping from v4 to v5 is not just a tag push - it requires a new branch with an updated `go.mod`. When `bin/release.sh major` is run and the `v{major+1}` branch does not exist, the script:

1. Pushes a new `v{major+1}` branch from the current major branch
2. Creates a setup branch, rewrites the module path in `go.mod` and all `.go` / `.md` files (`github.com/chartmogul/chartmogul-go/v4` → `/v5`), and commits
3. Opens a PR against the new `v{major+1}` branch with a description containing the admin checklist below
4. Exits - you merge the PR, do the admin tasks, then re-run `bin/release.sh major` to tag `v{major+1}.0.0`

Remaining manual steps on a major release:

- Merge the auto-opened setup PR
- Switch the default branch to `v{major+1}` (Settings > General)
- Extend the branch-protection ruleset to cover `v{major+1}`
- Visit pkg.go.dev to trigger indexing (after the first tag is pushed)
- Re-run `bin/release.sh major`

Everything else is already major-agnostic: the test workflow matches any `v*` branch, the coverage step derives its module path from `go list -m`, the release workflow runs on all `v*` tags, and the README has no hardcoded version.

## Pre-merge admin setup

- [x] **Immutable Releases**
  - [x] Settings > General > Releases > Enable "Immutable releases"
- [x] **Tag Protection Ruleset**
  - [x] Settings > Rules > Rulesets > New ruleset targeting tags matching `v*`
  - [x] Enable deletion prevention
  - [x] Enable force-push prevention
  - [x] Enable update prevention

## Post-merge steps

- [ ] **Verify automated release**
  - [x] Tag a pre-release (`v4.X.Y-rc1`) and confirm it creates a GitHub Release
  - [ ] If the previous item is OK, run `bin/release.sh minor` and confirm it works end to end
