### PR TITLE
Make RetryConfig.Enabled a *bool

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -19,8 +19,8 @@ var errRetry = errors.New("Retrying")
 
 // RetryConfig allows configuring the retry behavior for API requests.
 type RetryConfig struct {
-	// Enabled controls whether retries are enabled. Defaults to true.
-	Enabled bool
+	// Defaults to true.
+	Enabled *bool
 	// Maximum total time for retries. Defaults to backoff's default (15 minutes).
 	MaxElapsedTime time.Duration
 	// Maximum interval between retries. Defaults to backoff's default (60 seconds).
@@ -29,7 +29,8 @@ type RetryConfig struct {
 
 // defaultRetryConfig returns the default retry configuration (enabled, using backoff defaults).
 func defaultRetryConfig() *RetryConfig {
-	return &RetryConfig{Enabled: true}
+	enabled := true
+	return &RetryConfig{Enabled: &enabled}
 }
 
 // backoffStrategy creates a backoff strategy based on the API's retry config.
@@ -38,7 +39,7 @@ func (api API) backoffStrategy() backoff.BackOff {
 	if cfg == nil {
 		cfg = defaultRetryConfig()
 	}
-	if !cfg.Enabled {
+	if cfg.Enabled != nil && !*cfg.Enabled {
 		return &backoff.StopBackOff{}
 	}
 	b := backoff.NewExponentialBackOff()

--- a/generic_test.go
+++ b/generic_test.go
@@ -21,9 +21,10 @@ func TestRetryDisabled(t *testing.T) {
 	defer server.Close()
 	SetURL(server.URL + "/v/%v")
 
+	enabled := false
 	tested := &API{
 		ApiKey: "token",
-		Retry:  &RetryConfig{Enabled: false},
+		Retry:  &RetryConfig{Enabled: &enabled},
 	}
 	err := tested.delete("path1/:uuid", "uuid1")
 	if err == nil {


### PR DESCRIPTION
Change `RetryConfig.Enabled` from `bool` to `*bool` so that a nil value (the struct zero value) falls through to the documented default of retries being on, rather than silently disabling retries.

## Breaking change

Callers constructing `RetryConfig` with a boolean literal for `Enabled` will not compile. Migration:

```go
// Before
api := cm.API{ApiKey: key, Retry: &cm.RetryConfig{Enabled: true}}

// After
enabled := true
api := cm.API{ApiKey: key, Retry: &cm.RetryConfig{Enabled: &enabled}}
```

With this change, both `Retry: nil` and `Retry: &cm.RetryConfig{}` correctly default to retries being on.
