### PR TITLE
Change ToggleSubscriptionEventDisabled id to uint64

### DIFF
--- a/chartmogul.go
+++ b/chartmogul.go
@@ -185,7 +185,7 @@ type IApi interface {
 	CreateSubscriptionEvent(newSubscriptionEvent *SubscriptionEvent) (*SubscriptionEvent, error)
 	UpdateSubscriptionEvent(subscriptionEvent *SubscriptionEvent) (*SubscriptionEvent, error)
 	DeleteSubscriptionEvent(deleteParams *DeleteSubscriptionEvent) error
-	ToggleSubscriptionEventDisabled(id string, params *ToggleSubscriptionEventDisabledParams) (*SubscriptionEvent, error)
+	ToggleSubscriptionEventDisabled(id uint64, params *ToggleSubscriptionEventDisabledParams) (*SubscriptionEvent, error)
 	ToggleSubscriptionEventDisabledByExternalID(params *ToggleSubscriptionEventDisabledByExternalIDParams) (*SubscriptionEvent, error)
 }
 

--- a/mock_chartmogul/chartmogul.go
+++ b/mock_chartmogul/chartmogul.go
@@ -1407,7 +1407,7 @@ func (mr *MockIApiMockRecorder) ToggleLineItemDisabled(arg0, arg1 interface{}) *
 }
 
 // ToggleSubscriptionEventDisabled mocks base method
-func (m *MockIApi) ToggleSubscriptionEventDisabled(arg0 string, arg1 *chartmogul.ToggleSubscriptionEventDisabledParams) (*chartmogul.SubscriptionEvent, error) {
+func (m *MockIApi) ToggleSubscriptionEventDisabled(arg0 uint64, arg1 *chartmogul.ToggleSubscriptionEventDisabledParams) (*chartmogul.SubscriptionEvent, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ToggleSubscriptionEventDisabled", arg0, arg1)
 	ret0, _ := ret[0].(*chartmogul.SubscriptionEvent)

--- a/subscription_events.go
+++ b/subscription_events.go
@@ -1,6 +1,9 @@
 package chartmogul
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 const (
 	subscriptionEventsEndpoint                  = "subscription_events"
@@ -107,9 +110,9 @@ func (api API) DeleteSubscriptionEvent(deleteParams *DeleteSubscriptionEvent) er
 }
 
 // ToggleSubscriptionEventDisabled toggles the disabled state of a subscription event by ID.
-func (api API) ToggleSubscriptionEventDisabled(id string, params *ToggleSubscriptionEventDisabledParams) (*SubscriptionEvent, error) {
+func (api API) ToggleSubscriptionEventDisabled(id uint64, params *ToggleSubscriptionEventDisabledParams) (*SubscriptionEvent, error) {
 	result := &SubscriptionEvent{}
-	path := strings.Replace(subscriptionEventDisabledStateEndpoint, ":id", id, 1)
+	path := strings.Replace(subscriptionEventDisabledStateEndpoint, ":id", strconv.FormatUint(id, 10), 1)
 	return result, api.update(path, "", params, result)
 }
 

--- a/subscription_events_test.go
+++ b/subscription_events_test.go
@@ -316,7 +316,7 @@ func TestToggleSubscriptionEventDisabled(t *testing.T) {
 	var tested IApi = &API{
 		ApiKey: "token",
 	}
-	result, err := tested.ToggleSubscriptionEventDisabled("12345", &ToggleSubscriptionEventDisabledParams{
+	result, err := tested.ToggleSubscriptionEventDisabled(12345, &ToggleSubscriptionEventDisabledParams{
 		Disabled: true,
 	})
 


### PR DESCRIPTION
`SubscriptionEvent.ID` is already typed as `uint64`. Accepting a `string` forced callers to format the number themselves (`strconv.FormatUint(evt.ID, 10)`) and lost type information in the process.

`ToggleSubscriptionEventDisabled` now accepts the subscription event ID as `uint64` instead of a pre-formatted `string`.

## Breaking change

Callers passing a string ID will no longer compile. Migration:

```go
// Before
api.ToggleSubscriptionEventDisabled("12345", params)

// After, with a literal
api.ToggleSubscriptionEventDisabled(12345, params)

// After, against a retrieved event
api.ToggleSubscriptionEventDisabled(evt.ID, params)
```