### PR TITLE
Tighten SubscriptionEvent.Errors to map[string]interface{}

### DIFF
--- a/subscription_events.go
+++ b/subscription_events.go
@@ -23,27 +23,27 @@ type ToggleSubscriptionEventDisabledByExternalIDParams struct {
 }
 
 type SubscriptionEvent struct {
-	ID                        uint64      `json:"id,omitempty"`
-	DataSourceUUID            string      `json:"data_source_uuid,omitempty"`
-	CustomerExternalID        string      `json:"customer_external_id,omitempty"`
-	SubscriptionSetExternalID string      `json:"subscription_set_external_id,omitempty"`
-	SubscriptionExternalID    string      `json:"subscription_external_id,omitempty"`
-	PlanExternalID            string      `json:"plan_external_id,omitempty"`
-	EventDate                 string      `json:"event_date,omitempty"`
-	EffectiveDate             string      `json:"effective_date,omitempty"`
-	EventType                 string      `json:"event_type,omitempty"`
-	ExternalID                string      `json:"external_id,omitempty"`
-	Errors                    interface{} `json:"errors,omitempty"`
-	CreatedAt                 string      `json:"created_at,omitempty"`
-	UpdatedAt                 string      `json:"updated_at,omitempty"`
-	Quantity                  int32       `json:"quantity,omitempty"`
-	Currency                  string      `json:"currency,omitempty"`
-	AmountInCents             int32       `json:"amount_in_cents,omitempty"`
-	TaxAmountInCents          int32       `json:"tax_amount_in_cents,omitempty"`
-	RetractedEventId          string      `json:"retracted_event_id,omitempty"`
-	EventOrder                int32       `json:"event_order,omitempty"`
-	Disabled                  *bool       `json:"disabled,omitempty"`
-	DisabledAt                string      `json:"disabled_at,omitempty"`
+	ID                        uint64                 `json:"id,omitempty"`
+	DataSourceUUID            string                 `json:"data_source_uuid,omitempty"`
+	CustomerExternalID        string                 `json:"customer_external_id,omitempty"`
+	SubscriptionSetExternalID string                 `json:"subscription_set_external_id,omitempty"`
+	SubscriptionExternalID    string                 `json:"subscription_external_id,omitempty"`
+	PlanExternalID            string                 `json:"plan_external_id,omitempty"`
+	EventDate                 string                 `json:"event_date,omitempty"`
+	EffectiveDate             string                 `json:"effective_date,omitempty"`
+	EventType                 string                 `json:"event_type,omitempty"`
+	ExternalID                string                 `json:"external_id,omitempty"`
+	Errors                    map[string]interface{} `json:"errors,omitempty"`
+	CreatedAt                 string                 `json:"created_at,omitempty"`
+	UpdatedAt                 string                 `json:"updated_at,omitempty"`
+	Quantity                  int32                  `json:"quantity,omitempty"`
+	Currency                  string                 `json:"currency,omitempty"`
+	AmountInCents             int32                  `json:"amount_in_cents,omitempty"`
+	TaxAmountInCents          int32                  `json:"tax_amount_in_cents,omitempty"`
+	RetractedEventId          string                 `json:"retracted_event_id,omitempty"`
+	EventOrder                int32                  `json:"event_order,omitempty"`
+	Disabled                  *bool                  `json:"disabled,omitempty"`
+	DisabledAt                string                 `json:"disabled_at,omitempty"`
 }
 
 type SubscriptionEvents struct {

--- a/subscription_events_test.go
+++ b/subscription_events_test.go
@@ -1,6 +1,7 @@
 package chartmogul
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -381,5 +382,50 @@ func TestToggleSubscriptionEventDisabledByExternalID(t *testing.T) {
 	}
 	if result.Disabled == nil || *result.Disabled != false {
 		t.Error("Expected disabled to be false")
+	}
+}
+
+func TestSubscriptionEventErrorsUnmarshalsAsMap(t *testing.T) {
+	payload := `{
+		"id": 42,
+		"external_id": "evt_1",
+		"errors": {
+			"currency": "must be present",
+			"event_date": ["must be a valid date", "must be in the past"]
+		}
+	}`
+
+	var evt SubscriptionEvent
+	if err := json.Unmarshal([]byte(payload), &evt); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if evt.Errors == nil {
+		t.Fatal("expected Errors to be populated")
+	}
+
+	if got, want := evt.Errors["currency"], "must be present"; got != want {
+		t.Errorf("Errors[\"currency\"] = %v, want %v", got, want)
+	}
+
+	eventDate, ok := evt.Errors["event_date"].([]interface{})
+	if !ok {
+		t.Fatalf("Errors[\"event_date\"] = %T, want []interface{}", evt.Errors["event_date"])
+	}
+	if len(eventDate) != 2 {
+		t.Errorf("Errors[\"event_date\"] has %d entries, want 2", len(eventDate))
+	}
+}
+
+func TestSubscriptionEventErrorsNilWhenAbsent(t *testing.T) {
+	payload := `{"id": 1, "external_id": "evt_2"}`
+
+	var evt SubscriptionEvent
+	if err := json.Unmarshal([]byte(payload), &evt); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if evt.Errors != nil {
+		t.Errorf("Errors = %v, want nil when the JSON payload has no errors field", evt.Errors)
 	}
 }


### PR DESCRIPTION
API returns the `errors` field as a JSON object keyed by field name. Typing the SDK field as the widest possible type (`interface{}`) forced every consumer to do a type assertion before they could read the keys. A more specific type makes the errors usable directly and self-documents the shape.

Change `SubscriptionEvent.Errors` from `interface{}` to `map[string]interface{}` to match the JSON object shape the API returns for validation errors.

## Breaking change

Any code that assigned a non-map value to `SubscriptionEvent.Errors`, or that did a type assertion like `evt.Errors.(map[string]interface{})`, will not compile. Typical read usage (`for k, v := range evt.Errors`) does not need changes beyond dropping the preceding type assertion.
