### PR TITLE
Add runtime deprecation warning to ListSubscriptions

### DIFF
--- a/subscriptions.go
+++ b/subscriptions.go
@@ -46,6 +46,7 @@ func (api API) CancelSubscription(subscriptionUUID string, cancelSubscriptionPar
 // ListSubscriptions lists all subscriptions for customer of given UUID.
 // DEPRECATED: Use MetricsListCustomerSubscriptions instead.
 func (api API) ListSubscriptions(cursor *Cursor, customerUUID string) (*Subscriptions, error) {
+	log.Println("[DEPRECATED] ListSubscriptions is deprecated. Use MetricsListCustomerSubscriptions instead.")
 	result := &Subscriptions{}
 	path := strings.Replace(subscriptionsEndpoint, ":customerUUID", customerUUID, 1)
 	query := make([]interface{}, 0, 1)


### PR DESCRIPTION
- Adds a `log.Println` deprecation warning at the top of `ListSubscriptions`, matching the runtime warnings already emitted by `ConnectSubscriptions` and `DisconnectSubscriptions`.
- The existing `// DEPRECATED` doc comment was silent at runtime; this gives consumers visible signal to migrate to `MetricsListCustomerSubscriptions`.
