### PR TITLE
Align release workflow Go matrix with test workflow (ARCH-635)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        go-version: ['1.21', '1.22', '1.23', '1.24']
+        go-version: ['1.23', '1.24', '1.25', '1.26']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package chartmogul
 
 // Version of the package
-var Version = "v4"
+var Version = "v5"


### PR DESCRIPTION
## tl;dr
Release-prep follow-up to #101. Aligns the release workflow's Go matrix with the test workflow and fixes the stale User-Agent version string, so the upcoming v5.1.0 release gate is correct.

[ARCH-635](https://linear.app/chartmogul/issue/ARCH-635)

## Why
#101 raised the module minimum to Go 1.23 (`go.mod`: `go 1.23.0`) and moved `test.yml` to a `1.23-1.26` matrix, but `.github/workflows/release.yml` was left on `1.21-1.24`.

The release job only creates the GitHub Release when its test matrix passes (`release` `needs: test`). The 1.21/1.22 entries no longer match a supported Go version: today they pass only by silently auto-downloading the 1.23 toolchain, so they do not actually test those versions and would hard-fail if toolchain download is ever restricted. Since `v*` tags and releases are immutable, a broken release cannot be re-cut on the same version - better to correct the gate before tagging.

## Changes
- `release.yml` matrix `['1.21','1.22','1.23','1.24']` -> `['1.23','1.24','1.25','1.26']`, matching `test.yml`
- `version.go` `Version` `"v4"` -> `"v5"` (feeds the `User-Agent: chartmogul-go/<version>` header; stale since the v5.0.0 cut)

## Verification
- After merge, confirm the Release workflow definition on `v5` lists Go `1.23`-`1.26` (Actions > Release, or the file on the `v5` branch).
- Confirm the client now sends `User-Agent: chartmogul-go/v5`: point a client at a request-dumping endpoint (e.g. the repo's `dump-server.js`) or inspect any outbound request from a build off this branch and check the `User-Agent` header reads `chartmogul-go/v5`.